### PR TITLE
Refactor Property Evaluation API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,7 @@ Configuration file for sphinx documentation builder.
 """
 
 import os
+import re
 import sys
 # Allow sphinx to find package for docstrings
 sys.path.insert(0, os.path.abspath('../../src/'))

--- a/src/mlte/properties/property.py
+++ b/src/mlte/properties/property.py
@@ -2,15 +2,62 @@
 Superclass for all model properties.
 """
 
+import abc
+import typing
+from typing import Dict, Any
 
-class Property:
+# The callable property instance methods
+PROPERTY_METHODS = ["evaluate", "__call__", "_evaluate"]
+
+# The callable property class methods
+PROPERTY_CLASS_METHODS = ["_semantics"]
+
+
+def _has_callable(type, name) -> bool:
+    """Determine if `type` has a callable attribute with the given name."""
+    return hasattr(type, name) and callable(getattr(type, name))
+
+
+class Property(metaclass=abc.ABCMeta):
     """
     The superclass for all model properties.
     """
 
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        """Define the interface for all concrete properties."""
+        return all(
+            _has_callable(subclass, method) for method in PROPERTY_METHODS
+        ) and all(
+            _has_callable(subclass, method) for method in PROPERTY_CLASS_METHODS
+        )
+
     def __init__(self, name: str):
         """
-        Initialize a new Property.
+        Initialize a new Property instance.
         :param name The name of the property
         """
         self.name = name
+
+    @abc.abstractmethod
+    @typing.no_type_check
+    def evaluate(self, *args, **kwargs) -> Any:
+        """Evaluate a property and return results with semantics."""
+        raise NotImplementedError("Cannot evaluate abstract property.")
+
+    def __call__(self, *args, **kwargs) -> Any:
+        """Evaluate a property and return results with semantics."""
+        return self.evaluate(*args, **kwargs)
+
+    @abc.abstractmethod
+    @typing.no_type_check
+    def _evaluate(self, *args, **kwargs) -> Dict[str, Any]:
+        """Evaluate a property and return results without semantics."""
+        raise NotImplementedError("Cannot evaluate abstract property.")
+
+    @abc.abstractstaticmethod
+    def _semantics(self, output: Dict[str, Any]) -> Any:
+        """
+        Dervice semantics from raw property output.
+        :param output: The raw output of the property
+        """

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ setenv =
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
-    pytest --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
Resolves #15.

This PR refactors the property evaluation API. Specifically, it introduces the syntax `property.evaluate()` in conjunction with the standard overload of the `__call__()` method for properties.

Furthermore, this PR introduces an additional level of indirection that will be necessary when we generate reports from collections of properties. Each property must now implement an `_evaluate()` method that returns the "raw" result of the property. We combine this with a static `_semantics()` method to recover the semantics of the property output in `evaluate()`.

Finally, this PR standardizes the interface for properties with the help of a metaclass attached to the `Property` base.