### PR TITLE
Property Evaluation API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,3 +47,4 @@ autoapi_type = "python"
 autoapi_dirs = ["../../src"]
 autoapi_options = ["members", "special-members", "undoc-members", "imported-members"]
 autoapi_add_toctree_entry = False
+autoapi_python_class_content = "both"

--- a/src/mlte/properties/__init__.py
+++ b/src/mlte/properties/__init__.py
@@ -1,0 +1,5 @@
+from .property import Property
+from .property_token import PropertyToken
+
+# TODO: Remove PropertyToken from export
+__all__ = ["Property", "PropertyToken"]

--- a/src/mlte/properties/cpu/local_process_cpu_utilization.py
+++ b/src/mlte/properties/cpu/local_process_cpu_utilization.py
@@ -35,8 +35,13 @@ class CPUStatistics(EvaluationResult):
         super().__init__(property)
 
         self.avg = avg
+        """The average CPU utilization."""
+
         self.min = min
+        """The minimum CPU utilization."""
+
         self.max = max
+        """The maximum CPU utilization."""
 
     def __str__(self) -> str:
         """Return a string representation of CPUStatistics."""

--- a/src/mlte/properties/cpu/local_process_cpu_utilization.py
+++ b/src/mlte/properties/cpu/local_process_cpu_utilization.py
@@ -8,20 +8,23 @@ from typing import Dict, Any
 from subprocess import SubprocessError
 
 from ..property import Property
+from ..result import EvaluationResult
 from ...platform.os import is_windows
 
 
-class CPUStatistics:
+class CPUStatistics(EvaluationResult):
     """
     The CPUStatistics class encapsulates data
     and functionality for tracking and updating
     CPU consumption statistics for a running process.
     """
 
-    def __init__(self, avg: float, min: float, max: float):
+    def __init__(self, property: Property, avg: float, min: float, max: float):
         """
         Initialize a CPUStatistics instance.
 
+        :param property: The generating property
+        :type property: Property
         :param avg: The average utilization
         :type avg: float
         :param min: The minimum utilization
@@ -29,6 +32,8 @@ class CPUStatistics:
         :param max: The maximum utilization
         :type max: float
         """
+        super().__init__(property)
+
         self.avg = avg
         self.min = min
         self.max = max
@@ -74,7 +79,7 @@ class LocalProcessCPUUtilization(Property):
                 f"Property {self.name} is not supported on Windows."
             )
 
-    def evaluate(self, pid: int, poll_interval: int = 1) -> CPUStatistics:
+    def __call__(self, pid: int, poll_interval: int = 1) -> Dict[str, Any]:
         """
         Monitor the CPU utilization of process at `pid` until exit.
 
@@ -84,14 +89,8 @@ class LocalProcessCPUUtilization(Property):
         :type poll_interval: int
 
         :return: The collection of CPU usage statistics
-        :rtype: CPUStatistics
+        :rtype: Dict
         """
-        return LocalProcessCPUUtilization._semantics(
-            self._evaluate(pid, poll_interval)
-        )
-
-    def _evaluate(self, pid: int, poll_interval: int) -> Dict[str, Any]:
-        """See evaluate()."""
         stats = []
         while True:
             util = _get_cpu_usage(pid)
@@ -106,14 +105,22 @@ class LocalProcessCPUUtilization(Property):
             "max_utilization": max(stats),
         }
 
-    @staticmethod
-    def _semantics(output: Dict[str, Any]) -> CPUStatistics:
-        """Provide semantics for property output."""
-        assert "avg_utilization" in output, "Broken invariant."
-        assert "min_utilization" in output, "Broken invariant."
-        assert "max_utilization" in output, "Broken invariant."
+    def semantics(self, data: Dict[str, Any]) -> CPUStatistics:
+        """
+        Provide semantics for property output.
+
+        :param data: Property output data
+        :type data: Dict
+
+        :return: CPU utilization statistics
+        :rtype: CPUStatistics
+        """
+        assert "avg_utilization" in data, "Broken invariant."
+        assert "min_utilization" in data, "Broken invariant."
+        assert "max_utilization" in data, "Broken invariant."
         return CPUStatistics(
-            avg=output["avg_utilization"],
-            min=output["min_utilization"],
-            max=output["max_utilization"],
+            self,
+            avg=data["avg_utilization"],
+            min=data["min_utilization"],
+            max=data["max_utilization"],
         )

--- a/src/mlte/properties/memory/local_process_memory_consumption.py
+++ b/src/mlte/properties/memory/local_process_memory_consumption.py
@@ -7,20 +7,23 @@ import subprocess
 from typing import Dict, Any
 
 from ..property import Property
+from ..result import EvaluationResult
 from ...platform.os import is_windows
 
 
-class MemoryStatistics:
+class MemoryStatistics(EvaluationResult):
     """
     The MemoryStatistics class encapsulates data
     and functionality for tracking and updating memory
     consumption statistics for a running process.
     """
 
-    def __init__(self, avg: float, min: int, max: int):
+    def __init__(self, property: Property, avg: float, min: int, max: int):
         """
         Initialize a MemoryStatistics instance.
 
+        :param property: The generating property
+        :type property: Property
         :param avg: The average memory consumtion (bytes)
         :type avg: float
         :param min: The minimum memory consumption (bytes)
@@ -28,7 +31,8 @@ class MemoryStatistics:
         :param max: The maximum memory consumption (bytes)
         :type max: float
         """
-        # The statistics
+        super().__init__(property)
+
         self.avg = avg
         self.min = min
         self.max = max
@@ -78,7 +82,7 @@ class LocalProcessMemoryConsumption(Property):
                 f"Property {self.name} is not supported on Windows."
             )
 
-    def evaluate(self, pid: int, poll_interval: int = 1) -> MemoryStatistics:
+    def __call__(self, pid: int, poll_interval: int = 1) -> Dict[str, Any]:
         """
         Monitor memory consumption of process at `pid` until exit.
 
@@ -88,14 +92,8 @@ class LocalProcessMemoryConsumption(Property):
         :type poll_interval: int
 
         :return The collection of memory usage statistics
-        :rtype: MemoryStatistics
+        :rtype: Dict
         """
-        return LocalProcessMemoryConsumption._semantics(
-            self._evaluate(pid, poll_interval)
-        )
-
-    def _evaluate(self, pid: int, poll_interval: int) -> Dict[str, Any]:
-        """See evaluate()."""
         stats = []
         while True:
             kb = _get_memory_usage(pid)
@@ -110,14 +108,22 @@ class LocalProcessMemoryConsumption(Property):
             "max_consumption": max(stats),
         }
 
-    @staticmethod
-    def _semantics(output: Dict[str, Any]) -> MemoryStatistics:
-        """Provide semantics for property output."""
-        assert "avg_consumption" in output, "Broken invariant."
-        assert "min_consumption" in output, "Broken invariant."
-        assert "max_consumption" in output, "Broken invariant."
+    def semantics(self, data: Dict[str, Any]) -> MemoryStatistics:
+        """
+        Provide semantics for property output.
+
+        :param data: Property output data
+        :type data: Dict
+
+        :return: Memory consumption statistics
+        :rtype: MemoryStatistics
+        """
+        assert "avg_consumption" in data, "Broken invariant."
+        assert "min_consumption" in data, "Broken invariant."
+        assert "max_consumption" in data, "Broken invariant."
         return MemoryStatistics(
-            avg=output["avg_consumption"],
-            min=output["min_consumption"],
-            max=output["max_consumption"],
+            self,
+            avg=data["avg_consumption"],
+            min=data["min_consumption"],
+            max=data["max_consumption"],
         )

--- a/src/mlte/properties/memory/local_process_memory_consumption.py
+++ b/src/mlte/properties/memory/local_process_memory_consumption.py
@@ -24,18 +24,23 @@ class MemoryStatistics(EvaluationResult):
 
         :param property: The generating property
         :type property: Property
-        :param avg: The average memory consumtion (bytes)
+        :param avg: The average memory consumption
         :type avg: float
-        :param min: The minimum memory consumption (bytes)
+        :param min: The minimum memory consumption
         :type avg: float
-        :param max: The maximum memory consumption (bytes)
+        :param max: The maximum memory consumption
         :type max: float
         """
         super().__init__(property)
 
         self.avg = avg
+        """The average memory consumption (KB)."""
+
         self.min = min
+        """The minimum memory consumption (KB)."""
+
         self.max = max
+        """The maximum memory consumption (KB)."""
 
     def __str__(self) -> str:
         """Return a string representation of MemoryStatistics."""

--- a/src/mlte/properties/property_token.py
+++ b/src/mlte/properties/property_token.py
@@ -28,6 +28,7 @@ class PropertyToken:
         self.hash = uuid.uuid4().hex
 
     def __eq__(self, other: object) -> bool:
+        """Determine if two PropertyToken instances are equal."""
         if not isinstance(other, PropertyToken):
             return False
         return (
@@ -36,6 +37,7 @@ class PropertyToken:
         )
 
     def __ne__(self, other: object) -> bool:
+        """Determine if two PropertyToken instances are not equal."""
         return not self.__eq__(other)
 
     def __str__(self) -> str:

--- a/src/mlte/properties/property_token.py
+++ b/src/mlte/properties/property_token.py
@@ -1,0 +1,43 @@
+"""
+A unique identifier for instances of the Property class.
+"""
+
+import uuid
+
+
+class PropertyToken:
+    """
+    A PropertyToken is a unique identifier for a Property instance.
+    The PropertyToken goes beyond identifying the name of the
+    property, and actually identifies the particular instance to
+    which it is attached. Two instances of the same property with
+    identical attributes will have distinct PropertyTokens.
+    """
+
+    def __init__(self, property_name: str):
+        """
+        Initialize a PropertyToken instance.
+
+        :param property_name: The name of the property
+        to which this token is attached
+        :type property_name: str
+        """
+        # The name of the owning property
+        self.property_name = property_name
+        # A random, unique identifier for the instance
+        self.hash = uuid.uuid4().hex
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PropertyToken):
+            return False
+        return (
+            self.property_name == other.property_name
+            and self.hash == other.hash
+        )
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
+    def __str__(self) -> str:
+        """Return a string representation of the PropertyToken."""
+        return f"{self.property_name}, {self.hash}"

--- a/src/mlte/properties/result/__init__.py
+++ b/src/mlte/properties/result/__init__.py
@@ -1,0 +1,5 @@
+from .evalution_result import EvaluationResult
+from .integer import Integer
+from .opaque import Opaque
+
+__all__ = ["EvaluationResult", "Opaque", "Integer"]

--- a/src/mlte/properties/result/evalution_result.py
+++ b/src/mlte/properties/result/evalution_result.py
@@ -1,0 +1,26 @@
+"""
+Indicates the outcome of property evaluation.
+"""
+
+import abc
+
+
+class EvaluationResult(metaclass=abc.ABCMeta):
+    """
+    The EvaluationResult class serves as the base class of
+    all semantically-enriched property evaluation results.
+    The EvaluationResult provides a common interface for
+    inspecting the results of property evaluation, and also
+    encapsulates the functionality required to uniquely
+    associate evaluation results with the originating property.
+    """
+
+    def __init__(self, property):
+        """
+        Initialize an EvaluationResult instance.
+
+        :param property: The generating property
+        :type property: Property
+        """
+        # Store the token of the generating property
+        self.token = property.token

--- a/src/mlte/properties/result/integer.py
+++ b/src/mlte/properties/result/integer.py
@@ -1,0 +1,28 @@
+"""
+An EvaluationResult instance for single, integer values.
+"""
+
+from .evalution_result import EvaluationResult
+
+
+class Integer(EvaluationResult):
+    """
+    Integer implements the EvaluationResult
+    interface for a single integer value.
+    """
+
+    def __init__(self, property, value: int):
+        """
+        Initialize an Integer instance.
+
+        :param property: The generating property
+        :type property: Property
+        :param value: The integer value
+        :type value: int
+        """
+        super().__init__(property)
+        self.value = value
+
+    def __str__(self) -> str:
+        """Return a string representation of the Integer."""
+        return f"{self.value}"

--- a/src/mlte/properties/result/integer.py
+++ b/src/mlte/properties/result/integer.py
@@ -21,7 +21,9 @@ class Integer(EvaluationResult):
         :type value: int
         """
         super().__init__(property)
+
         self.value = value
+        """The wrapped integer value."""
 
     def __str__(self) -> str:
         """Return a string representation of the Integer."""

--- a/src/mlte/properties/result/opaque.py
+++ b/src/mlte/properties/result/opaque.py
@@ -23,5 +23,6 @@ class Opaque(EvaluationResult):
         :type data: Dict
         """
         super().__init__(property)
-        # The raw output dictionary from property invocation
+
         self.data = data
+        """The raw output from property execution."""

--- a/src/mlte/properties/result/opaque.py
+++ b/src/mlte/properties/result/opaque.py
@@ -1,0 +1,27 @@
+"""
+An opaque evaluation result, without semantics.
+"""
+
+from typing import Dict, Any
+
+from .evalution_result import EvaluationResult
+
+
+class Opaque(EvaluationResult):
+    """
+    The 'default' EvaluationResult instance for custom
+    properties that do not define a `semantics()` method.
+    """
+
+    def __init__(self, property, data: Dict[str, Any]):
+        """
+        Initialize an Opaque instance.
+
+        :param property: The generating property
+        :type property: Property
+        :param data: The output of the property
+        :type data: Dict
+        """
+        super().__init__(property)
+        # The raw output dictionary from property invocation
+        self.data = data

--- a/src/mlte/properties/storage/local_model_size.py
+++ b/src/mlte/properties/storage/local_model_size.py
@@ -6,6 +6,7 @@ import os
 from typing import Dict, Any
 
 from ..property import Property
+from ..result import Integer
 
 
 class LocalModelSize(Property):
@@ -15,7 +16,7 @@ class LocalModelSize(Property):
         """Initialize a new LocalModelSize property."""
         super().__init__("LocalModelSize")
 
-    def evaluate(self, path: str) -> int:
+    def __call__(self, path: str) -> Dict[str, Any]:
         """
         Compute the size of the model at `path`.
 
@@ -23,12 +24,8 @@ class LocalModelSize(Property):
         :type path: str
 
         :return: The size of the model, in bytes
-        :rtype: int
+        :rtype: Dict
         """
-        return LocalModelSize._semantics(self._evaluate(path))
-
-    def _evaluate(self, path: str) -> Dict[str, Any]:
-        """See evaluate()."""
         if not os.path.isfile(path) and not os.path.isdir(path):
             raise RuntimeError(f"Invalid path: {path}")
 
@@ -48,8 +45,7 @@ class LocalModelSize(Property):
 
         return {"total_size": total_size}
 
-    @staticmethod
-    def _semantics(output: Dict[str, Any]) -> int:
+    def semantics(self, data: Dict[str, Any]) -> Integer:
         """Provide semantics for property output."""
-        assert "total_size" in output, "Broken invariant."
-        return int(output["total_size"])
+        assert "total_size" in data, "Broken invariant."
+        return Integer(self, data["total_size"])

--- a/test/properties/cpu/test_local_process_cpu_utilization.py
+++ b/test/properties/cpu/test_local_process_cpu_utilization.py
@@ -37,7 +37,7 @@ def test_cpu_nix():
     prop = LocalProcessCPUUtilization()
 
     # Capture CPU utilization; blocks until process exit
-    stat = prop(prog.pid)
+    stat = prop.evaluate(prog.pid)
 
     assert len(str(stat)) > 0
     # Test for passage of time

--- a/test/properties/memory/test_local_process_memory_consumption.py
+++ b/test/properties/memory/test_local_process_memory_consumption.py
@@ -36,7 +36,7 @@ def test_memory_nix():
     prop = LocalProcessMemoryConsumption()
 
     # Capture memory consumption; blocks until process exit
-    stat = prop(prog.pid)
+    stat = prop.evaluate(prog.pid)
 
     assert len(str(stat)) > 0
     assert int(time.time() - start) >= SPIN_DURATION

--- a/test/properties/storage/test_local_model_size.py
+++ b/test/properties/storage/test_local_model_size.py
@@ -101,9 +101,9 @@ def test_file():
     create_fs_hierarchy(model)
 
     prop = LocalModelSize()
-    size = prop("model")
+    size = prop.evaluate("model")
 
-    assert size == expected_hierarchy_size(model)
+    assert size.value == expected_hierarchy_size(model)
     os.remove("model")
 
 
@@ -113,7 +113,7 @@ def test_directory():
     create_fs_hierarchy(model)
 
     prop = LocalModelSize()
-    size = prop("model")
+    size = prop.evaluate("model")
 
-    assert size == expected_hierarchy_size(model)
+    assert size.value == expected_hierarchy_size(model)
     shutil.rmtree("model")

--- a/test/properties/test_property_token.py
+++ b/test/properties/test_property_token.py
@@ -1,0 +1,17 @@
+"""
+Unit tests for PropertyToken.
+"""
+
+from mlte.properties import PropertyToken
+
+
+def test_equality():
+    a = PropertyToken("Test")
+    b = a
+    assert a == b
+
+
+def test_inequality():
+    a = PropertyToken("Test")
+    b = PropertyToken("Test")
+    assert a != b

--- a/testbed/main.py
+++ b/testbed/main.py
@@ -1,0 +1,19 @@
+"""
+A simple program for testing functionality during development.
+"""
+
+import sys
+from resolver import package_root
+sys.path.append(package_root())
+
+from mlte.properties.cpu import LocalProcessCPUUtilization
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
+def main() -> int:
+    p = LocalProcessCPUUtilization()
+    return EXIT_SUCCESS
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testbed/resolver.py
+++ b/testbed/resolver.py
@@ -1,0 +1,12 @@
+"""
+Resolve the path to the `mlte` package.
+"""
+
+import os
+
+def package_root() -> str:
+    """Resolve the path to the project root."""
+    path = os.path.dirname(os.path.abspath(__file__))
+    while os.path.basename(os.path.abspath(path)) != "testbed":
+        path = os.path.join(path, "..")
+    return os.path.abspath(os.path.join(path, "..", "src/"))


### PR DESCRIPTION
This PR refactors the property evaluation API (again).

The refactor focuses on simplifying the process of authoring custom properties. Specifically, users of the package need only implement a single method, `__call__()`, in order to create a fully-functional property. In addition to this, we provide the _option_ of providing a `semantics()` method to interpret the result of property execution. If `semantics()` is not provided, we supply a default implementation of `EvaluationResult` that simply wraps the raw data produced by the property.

Furthermore, this PR introduces functionality to 'link' an `EvaluationResult` with the property that produced it. This is a necessary step for implementing Suites.