### PR TITLE
Add `Real` Type

### DIFF
--- a/src/mlte/measurement/evaluation/__init__.py
+++ b/src/mlte/measurement/evaluation/__init__.py
@@ -1,5 +1,6 @@
 from .evalution_result import EvaluationResult
 from .opaque import Opaque
 from .integer import Integer
+from .real import Real
 
-__all__ = ["EvaluationResult", "Opaque", "Integer"]
+__all__ = ["EvaluationResult", "Opaque", "Integer", "Real"]

--- a/src/mlte/measurement/evaluation/integer.py
+++ b/src/mlte/measurement/evaluation/integer.py
@@ -1,5 +1,5 @@
 """
-An EvaluationResult instance for single, integer values.
+An EvaluationResult instance for a scalar, integral value.
 """
 
 from .evalution_result import EvaluationResult
@@ -20,6 +20,8 @@ class Integer(EvaluationResult):
         :param value: The integer value
         :type value: int
         """
+        assert isinstance(value, int), "Argument must be `int`."
+
         super().__init__(measurement)
 
         self.value = value

--- a/src/mlte/measurement/evaluation/opaque.py
+++ b/src/mlte/measurement/evaluation/opaque.py
@@ -26,3 +26,23 @@ class Opaque(EvaluationResult):
 
         self.data = data
         """The raw output from measurement execution."""
+
+    def __getitem__(self, key: str) -> Any:
+        """
+        Access an item from the wrapped data object.
+
+        :param key: The key that identifies the item to access
+        :type key: str
+
+        :return: The value associated with `key`.
+        :rtype: Any
+
+        :raises KeyError: If the key is not present
+        """
+        if key not in self.data:
+            raise KeyError(f"Key {key} not found.")
+        return self.data[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        """Raise ValueError to indicate Opaque is read-only."""
+        raise ValueError("Opaque is read-only.")

--- a/src/mlte/measurement/evaluation/real.py
+++ b/src/mlte/measurement/evaluation/real.py
@@ -1,0 +1,32 @@
+"""
+An EvaluationResult instance for a scalar, real value.
+"""
+
+from .evalution_result import EvaluationResult
+
+
+class Real(EvaluationResult):
+    """
+    Real implements the EvaluationResult
+    interface for a single real value.
+    """
+
+    def __init__(self, measurement, value: float):
+        """
+        Initialize a Real instance.
+
+        :param measurement: The generating measurement
+        :type measurement: Measurement
+        :param value: The real value
+        :type value: float
+        """
+        assert isinstance(value, float), "Argument must be `float`."
+
+        super().__init__(measurement)
+
+        self.value = value
+        """The wrapped real value."""
+
+    def __str__(self) -> str:
+        """Return a string representation of the Real."""
+        return f"{self.value}"

--- a/test/measurement/test_evaluation.py
+++ b/test/measurement/test_evaluation.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for measurement evaluation functionality.
+"""
+
+import pytest
+from typing import Dict, Any
+
+from mlte.measurement import Measurement
+from mlte.measurement.evaluation import Opaque, Integer, Real
+
+
+class DummyMeasurementOpaque(Measurement):
+    def __init__(self):
+        super().__init__("DummyMeasurementOpaque")
+
+    def __call__(self) -> Dict[str, Any]:
+        return {"value": 1}
+
+
+def test_opaque():
+    m = DummyMeasurementOpaque()
+    t = m.evaluate()
+    assert isinstance(t, Opaque)
+
+    assert "value" in t.data
+    assert t.data["value"] == 1
+
+    # Opaque is subscriptable, like a dictionary
+    assert t["value"] == t.data["value"]
+
+    # Opaque raises for invalid key
+    with pytest.raises(KeyError):
+        _ = t["foo"]
+
+    # Opaque is read-only
+    with pytest.raises(ValueError):
+        t["value"] = 2  # type: ignore
+
+
+class DummyMeasurementInteger(Measurement):
+    def __init__(self):
+        super().__init__("DummyMeasurementInteger")
+
+    def __call__(self) -> Dict[str, Any]:
+        return {"value": 1}
+
+    def semantics(self, data: Dict[str, Any]) -> Integer:
+        return Integer(self, data["value"])
+
+
+def test_integer_success():
+    # Ensure instantiation succeeds for valid type
+    m = DummyMeasurementInteger()
+    i = Integer(m, 1)
+    assert i.value == 1
+
+
+def test_integer_fail():
+    # Ensure instantiation fails for invalid type
+    m = DummyMeasurementInteger()
+    with pytest.raises(AssertionError):
+        _ = Integer(m, 3.14)  # type: ignore
+
+
+def test_integer_e2e():
+    m = DummyMeasurementInteger()
+    i = m.evaluate()
+    assert isinstance(i, Integer)
+    assert i.value == 1
+
+
+class DummyMeasurementReal(Measurement):
+    def __init__(self):
+        super().__init__("DummyMeasurementReal")
+
+    def __call__(self) -> Dict[str, Any]:
+        return {"value": 3.14}
+
+    def semantics(self, data: Dict[str, Any]) -> Real:
+        return Real(self, data["value"])
+
+
+def test_real_success():
+    # Ensure instantiation succeeds for valid type
+    m = DummyMeasurementReal()
+    r = Real(m, 3.14)
+    assert r.value == 3.14
+
+
+def test_real_fail():
+    m = DummyMeasurementReal()
+    with pytest.raises(AssertionError):
+        _ = Real(m, 1)
+
+
+def test_real_e2e():
+    m = DummyMeasurementReal()
+    r = m.evaluate()
+    assert isinstance(r, Real)
+    assert r.value == 3.14


### PR DESCRIPTION
Resolves #29.
Resolves #30.

This PR introduces the following changes:
- Add a `Real` type for `EvaluationResult`
- Increase the functionality of `Opaque` to make it subscriptable
- Add tests for `Opaque`, `Integer` and `Real`