### PR TITLE
Refactor `artifacts_url` to `artifact_url`

### DIFF
--- a/src/mlte/report/report.py
+++ b/src/mlte/report/report.py
@@ -130,7 +130,7 @@ class Metadata(ReportAttribute):
     source_url: Optional[str] = None
     """The URL for model source."""
 
-    artifacts_url: Optional[str] = None
+    artifact_url: Optional[str] = None
     """The URL for model artifacts."""
 
     timestamp: Optional[str] = None

--- a/test/schema/test_report_schema.py
+++ b/test/schema/test_report_schema.py
@@ -21,7 +21,7 @@ def test_valid_instance():
     report.metadata.project_name = "ProjectName"
     report.metadata.authors = ["Foo", "Bar"]
     report.metadata.source_url = "https://github.com/mlte-team"
-    report.metadata.artifacts_url = "https://github.com/mlte-team"
+    report.metadata.artifact_url = "https://github.com/mlte-team"
     report.metadata.timestamp = f"{int(time.time())}"
 
     report.model_details.name = "ModelName"

--- a/testbed/main.py
+++ b/testbed/main.py
@@ -42,7 +42,7 @@ def build_report() -> Report:
     report.metadata.project_name = "ProjectName"
     report.metadata.authors = ["Foo", "Bar"]
     report.metadata.source_url = "https://github.com/mlte-team"
-    report.metadata.artifacts_url = "https://github.com/mlte-team"
+    report.metadata.artifact_url = "https://github.com/mlte-team"
     report.metadata.timestamp = f"{int(time.time())}"
 
     report.model_details.name = "ModelName"


### PR DESCRIPTION
This PR simply refactors `artifacts_url` to `artifact_url` within the `Report` functionality. A name change.

Resolves #45.