### PR TITLE
Refactor `Suite` to `Spec`

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -39,7 +39,7 @@ def load_model(path: str):
 ```
 
 ## Select Measurements
-Currently there are several measurements already implemented in *MLTE* measurement pacakage. As development continues, more measurements will be added. Below we demonstrate the process of binding measurements and their associated validators to the respective properties in a suite collection. 
+Currently there are several measurements already implemented in *MLTE* measurement pacakage. As development continues, more measurements will be added. Below we demonstrate the process of binding measurements and their associated validators to the respective properties in a specification collection. 
 
 ```python
 from mlte.measurement import bind
@@ -52,24 +52,24 @@ MB = 2**20
 GB = 2**30
 
 # Create a measurement for the size of the trained model;
-# attach a validator for the size, and bind to suite property
+# attach a validator for the size, and bind to spec property
 measure_size = bind(
     LocalObjectSize().with_validator_size_not_greater_than(threshold=64*MB),
-    suite.get_property("StorageCost")
+    spec.get_property("StorageCost")
 )
 
 # Create a measurement for the CPU utilization of the training process;
-# attach a validator for the maximum utilization, and bind to suite property
+# attach a validator for the maximum utilization, and bind to spec property
 measure_cpu = bind(
     LocalProcessCPUUtilization().with_validator_max_utilization_not_greater_than(threshold=0.9),
-    suite.get_property("TrainingComputeCost")
+    spec.get_property("TrainingComputeCost")
 )
 
 # Create a measurement for memory consumption of the training process;
-# attach a validator for the maximum consumption, and bind to suite property
+# attach a validator for the maximum consumption, and bind to spec property
 measure_mem = bind(
     LocalProcessMemoryConsumption().with_validator_max_consumption_not_greater_than(threshold=1*GB/KB),
-    suite.get_property("TrainingMemoryCost")
+    spec.get_property("TrainingMemoryCost")
 )
 ```
 
@@ -124,10 +124,10 @@ class ClassificationAccuracy(Measurement):
         )
 
 # Create a measurement for classification accuracy;
-# add a validator for the minimum acceptable accuracy, and bind to suite property
+# add a validator for the minimum acceptable accuracy, and bind to spec property
 measure_accuracy = bind(
     ClassificationAccuracy().with_validator_accuracy_not_less_than(threshold=0.65),
-    suite.get_property("Accuracy")
+    spec.get_property("Accuracy")
 )
 ```
 
@@ -173,11 +173,11 @@ print(cost_results[0][0].message)
 print(cost_results[1][0].message)
 ```
 
-## Build a Suite
-Suites are collections of properties that developers have prioritized for evaluating the model. Below we show the creation of a suite that contains four properties, accuracy, storage costs, training compute cost, and training memory cost. The Suite is named "DigitRecognizer1.0"
+## Build a Specification
+Specifications are collections of properties that developers have prioritized for evaluating the model. Below we show the creation of a spec that contains four properties, accuracy, storage costs, training compute cost, and training memory cost. The `Spec` is named "DigitRecognizer1.0"
 
 ```python
-from mlte.suites import Suite
+from mlte.spec import Spec
 from mlte.properties.costs import (
     StorageCost,
     TrainingComputeCost,
@@ -185,12 +185,12 @@ from mlte.properties.costs import (
 )
 from mlte.properties.functionality import Accuracy
 
-# Construct a suite with the selected properties
-suite = Suite("DigitRecognizer1.0")
-suite.add_property(Accuracy())
-suite.add_property(StorageCost())
-suite.add_property(TrainingComputeCost())
-suite.add_property(TrainingMemoryCost())
+# Construct a spec with the selected properties
+spec = Spec("DigitRecognizer1.0")
+spec.add_property(Accuracy())
+spec.add_property(StorageCost())
+spec.add_property(TrainingComputeCost())
+spec.add_property(TrainingMemoryCost())
 ```
 
 ## Build a Report

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -49,5 +49,3 @@ This glossary definitively represents the conventions applied in MLTE and its AP
 **Performance Metric:** After determining a baseline test, teams must pick a performance metric. There are a wide range of metrics that could be appropriate depending on the type of model and the context in which the task is performed. 
 
 **Scalability:** The ability of AI to perform at the size, speed, and complexity required. 
-
-**Suites:** Suites are collections of properties and their associated measurements and bound validators. Suites help contain and organize the *MLTE* properties so that models can be easily re-evaluted. They also aid in the generation of the *MLTE* report.

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -19,7 +19,7 @@ If you don’t have Python yet, you might want to consider using Anaconda. It’
 MLTE contains the following subpackages:
 - **Properties**: Properties are the characteristics or traits of a ML model or system. Developers will consider priorities, tradeoffs, and weaknesses of their model in the context of the system and prioritize properties for testing. The categories that organize properties are listed in [SDMT](https://github.com/mlte-team/a2it/blob/master/framework/1_SDMT.md). Properties in MLTE are an abstract element that are measured by measurements and validated by validators which are bound to properties. 
 - **Measurement**: Measurements are the isntances that assesses a property. For example, the total local process memory consumptions is a *measurement* that measures the *property* of Training Memory Cost. 
-- **Suites**: Suites are collections of properties and their associated measurements and bound validators. Suits help contain and organize the *MLTE* properties so that models can be easily re-evaluted. It also aids in the generation of the *MLTE* report. 
+- **Spec**: Specs are collections of properties and their associated measurements and bound validators. Suits help contain and organize the *MLTE* properties so that models can be easily re-evaluted. It also aids in the generation of the *MLTE* report. 
 - **Report**: Report contains a number of subclasses that are returned and displayed in the automatically generated *MLTE* report. The report renders as a web page and is opened automatically in an available window of the default browser. 
 
 ## Import
@@ -28,6 +28,6 @@ MLTE contains the following subpackages:
 ```python
 from mlte.properties ... #importing from properties subpackage
 from mlte.measurement ... #importing from measurement subpackage
-from mlte.suites ... #importing from suites subpackage
+from mlte.spec ... #importing from spec subpackage
 from mlte.report ... #importing from report subpackage
 ```

--- a/src/mlte/_private/schema.py
+++ b/src/mlte/_private/schema.py
@@ -15,13 +15,13 @@ import pkgutil
 import jsonschema
 from typing import Any, Dict, Optional
 
-# The identifier for the latest schema for suites
-SUITE_LATEST_SCHEMA_VERSION = "0.0.1"
+# The identifier for the latest schema for specs
+SPEC_LATEST_SCHEMA_VERSION = "0.0.1"
 # The identifier for the latest schema for reports
 REPORT_LATEST_SCHEMA_VERSION = "0.0.1"
 
-# Version identifiers for suite schemas
-_SUITE_SCHEMA_VERSIONS = frozenset(("0.0.1",))
+# Version identifiers for spec schemas
+_SPEC_SCHEMA_VERSIONS = frozenset(("0.0.1",))
 # Version identifier for report schemas
 _REPORT_SCHEMA_VERSIONS = frozenset(("0.0.1",))
 
@@ -33,11 +33,11 @@ _SCHEMA_FILE_NAME = "schema.json"
 # -----------------------------------------------------------------------------
 
 
-def validate_suite_schema(
+def validate_spec_schema(
     document: Dict[str, Any], version: Optional[str] = None
 ):
     """
-    Validate the schema of a suite output document.
+    Validate the schema of a spec output document.
 
     :param document: The document instance
     :type document: Dict[str, Any]
@@ -48,16 +48,16 @@ def validate_suite_schema(
     :raises ValidationError: If the instance fails validation
     """
     version = (
-        version or document.get("schema_version") or SUITE_LATEST_SCHEMA_VERSION
+        version or document.get("schema_version") or SPEC_LATEST_SCHEMA_VERSION
     )
-    jsonschema.validate(instance=document, schema=_find_suite_schema(version))
+    jsonschema.validate(instance=document, schema=_find_spec_schema(version))
 
 
 def validate_report_schema(
     document: Dict[str, Any], version: Optional[str] = None
 ):
     """
-    Validate the schema of a suite output document.
+    Validate the schema of a spec output document.
 
     :param document: The document instance
     :type document: Dict[str, Any]
@@ -105,9 +105,9 @@ def _find_schema(version: str, subdirectory: str) -> Dict[str, Any]:
     return json.loads(data)  # type: ignore
 
 
-def _find_suite_schema(version: Optional[str] = None) -> Dict[str, Any]:
+def _find_spec_schema(version: Optional[str] = None) -> Dict[str, Any]:
     """
-    Find, load, and return the JSON schema for suite output.
+    Find, load, and return the JSON schema for spec output.
 
     :param version: The version identifier for the schema
     :type version: Optional[str]
@@ -118,10 +118,10 @@ def _find_suite_schema(version: Optional[str] = None) -> Dict[str, Any]:
     :raises ValueError: If an invalid schema is specified
     """
     if version is None:
-        version = SUITE_LATEST_SCHEMA_VERSION
-    if version not in _SUITE_SCHEMA_VERSIONS:
-        raise ValueError(f"Invalid suite schema version {version} specified.")
-    return _find_schema(version, "suite")
+        version = SPEC_LATEST_SCHEMA_VERSION
+    if version not in _SPEC_SCHEMA_VERSIONS:
+        raise ValueError(f"Invalid spec schema version {version} specified.")
+    return _find_schema(version, "spec")
 
 
 def _find_report_schema(version: Optional[str] = None):

--- a/src/mlte/report/report.py
+++ b/src/mlte/report/report.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any, Union
 
 from .html import _connected, _generate_html
-from ..suite import SuiteReport
+from ..spec import SpecReport
 
 from .._private.text import cleantext
 from .._private.schema import REPORT_LATEST_SCHEMA_VERSION
@@ -208,8 +208,8 @@ class Report(ReportAttribute):
     considerations: Considerations = field(default_factory=Considerations)
     """Model considerations."""
 
-    suite: SuiteReport = field(default_factory=lambda: SuiteReport({}))
-    """The model test suite report."""
+    spec: SpecReport = field(default_factory=lambda: SpecReport({}))
+    """The model test spec report."""
 
     def _finalize(self) -> Dict[str, Any]:
         """
@@ -223,8 +223,8 @@ class Report(ReportAttribute):
             self,
             dict_factory=lambda properties: {k: v for k, v in properties if v},
         )
-        # Manually serialize the suite-level document
-        document["suite"] = self.suite.document
+        # Manually serialize the spec-level document
+        document["spec"] = self.spec.document
         # Manually insert the schema version
         document["schema_version"] = REPORT_LATEST_SCHEMA_VERSION
         return document

--- a/src/mlte/schema/report/v0.0.1/schema.json
+++ b/src/mlte/schema/report/v0.0.1/schema.json
@@ -109,9 +109,9 @@
                 }
             }
         },
-        "suite": {
+        "spec": {
             "type": "object",
-            "description": "The model test suite results."
+            "description": "The model test spec results."
         }
     },
     "additionalProperties": false,

--- a/src/mlte/schema/spec/v0.0.1/schema.json
+++ b/src/mlte/schema/spec/v0.0.1/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Suite Report",
+    "title": "Specification Report",
     "type": "object",
     "properties": {
         "schema_version": {
@@ -9,7 +9,7 @@
         },
         "name": {
             "type": "string",
-            "description": "A human-readable identifier for the suite."
+            "description": "A human-readable identifier for the specification."
         },
         "timestamp": {
             "type": "string",
@@ -17,7 +17,7 @@
         },
         "properties": {
             "type": "array",
-            "description": "The set of properties that compose the suite.",
+            "description": "The set of properties that compose the specification.",
             "items": {
                 "type": "object",
                 "properties": {

--- a/src/mlte/spec/__init__.py
+++ b/src/mlte/spec/__init__.py
@@ -1,0 +1,3 @@
+from .spec import Spec, SpecReport
+
+__all__ = ["Spec", "SpecReport"]

--- a/src/mlte/suite/__init__.py
+++ b/src/mlte/suite/__init__.py
@@ -1,3 +1,0 @@
-from .suite import Suite, SuiteReport
-
-__all__ = ["Suite", "SuiteReport"]

--- a/test/schema/test_report_schema.py
+++ b/test/schema/test_report_schema.py
@@ -7,7 +7,7 @@ import pytest
 from jsonschema import ValidationError
 
 from mlte.report import Report, Dataset, User, UseCase, Limitation
-from mlte.suite import SuiteReport
+from mlte.spec import SpecReport
 from mlte._private.schema import validate_report_schema
 
 
@@ -50,7 +50,7 @@ def test_valid_instance():
         Limitation("Limitation description 1."),
     ]
 
-    report.suite = SuiteReport({})
+    report.spec = SpecReport({})
 
     validate_report_schema(report.to_json())
 

--- a/test/schema/test_suite_schema.py
+++ b/test/schema/test_suite_schema.py
@@ -5,52 +5,52 @@ Unit tests for report schemas.
 import pytest
 from jsonschema import ValidationError
 
-from mlte.suite import Suite
+from mlte.spec import Spec
 from mlte.property.costs import StorageCost
 
 from mlte.measurement import bind
 from mlte.measurement.utility import flatten
 from mlte.measurement.storage import LocalObjectSize
 
-from mlte._private.schema import validate_suite_schema
+from mlte._private.schema import validate_spec_schema
 
 
 def test_empty_instance():
     # Ensure that an empty report passes validation
-    suite = Suite("MySuite")
-    report = suite.collect()
-    validate_suite_schema(report.document)
+    spec = Spec("MySpec")
+    report = spec.collect()
+    validate_spec_schema(report.document)
 
 
 def test_instance_with_content():
     # Ensure that a report with content passes validation
-    suite = Suite("MySuite", StorageCost())
+    spec = Spec("MySpec", StorageCost())
 
     local_size = bind(
         LocalObjectSize().with_validator_size_not_greater_than(threshold=54000),
-        suite.get_property("StorageCost"),
+        spec.get_property("StorageCost"),
     )
 
     size_result = local_size.validate("test/")
-    report = suite.collect(*flatten(size_result))
+    report = spec.collect(*flatten(size_result))
 
-    validate_suite_schema(report.document)
+    validate_spec_schema(report.document)
 
 
 def test_failure():
-    # Test that an invalid suite fails validation
-    suite = Suite("MySuite", StorageCost())
+    # Test that an invalid spec fails validation
+    spec = Spec("MySpec", StorageCost())
 
     local_size = bind(
         LocalObjectSize().with_validator_size_not_greater_than(threshold=54000),
-        suite.get_property("StorageCost"),
+        spec.get_property("StorageCost"),
     )
 
     size_result = local_size.validate("test/")
-    report = suite.collect(*flatten(size_result))
+    report = spec.collect(*flatten(size_result))
 
     # Remove a required field
     del report.document["name"]
 
     with pytest.raises(ValidationError):
-        validate_suite_schema(report.document)
+        validate_spec_schema(report.document)

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -1,12 +1,12 @@
 """
-Unit tests for Suite functionality.
+Unit tests for Spec functionality.
 """
 
 import os
 import pytest
 from typing import Dict, Any
 
-from mlte.suite import Suite
+from mlte.spec import Spec
 from mlte.property import Property
 from mlte.measurement import Measurement, bind
 from mlte.measurement.validation import Validator, Success
@@ -35,78 +35,78 @@ class DummyMeasurement1(Measurement):
 
 
 def test_save(tmp_path):
-    path = os.path.join(tmp_path.as_posix(), "suite.json")
+    path = os.path.join(tmp_path.as_posix(), "spec.json")
 
-    suite = Suite("MySuite", StorageCost())
-    suite.save(path)
+    spec = Spec("MySpec", StorageCost())
+    spec.save(path)
     assert os.path.exists(path) and os.path.isfile(path)
 
 
 def test_load(tmp_path):
-    path = os.path.join(tmp_path.as_posix(), "suite.json")
+    path = os.path.join(tmp_path.as_posix(), "spec.json")
 
-    suite = Suite("MySuite", StorageCost())
-    suite.save(path)
+    spec = Spec("MySpec", StorageCost())
+    spec.save(path)
     assert os.path.exists(path) and os.path.isfile(path)
 
-    suite = Suite.from_file(path)
-    assert suite.name == "MySuite"
-    assert suite.has_property("StorageCost")
+    spec = Spec.from_file(path)
+    assert spec.name == "MySpec"
+    assert spec.has_property("StorageCost")
 
 
 def test_bind0():
     # Binding to existing property should succeed
-    suite = Suite("MySuite", DummyProperty())
-    _ = bind(DummyMeasurement0(), suite.get_property("DummyProperty"))
+    spec = Spec("MySpec", DummyProperty())
+    _ = bind(DummyMeasurement0(), spec.get_property("DummyProperty"))
     assert True
 
 
 def test_bind1():
     # Binding to nonexistent property should fail
-    suite = Suite("MySuite")
+    spec = Spec("MySpec")
     with pytest.raises(RuntimeError):
-        _ = bind(DummyMeasurement0(), suite.get_property("DummyProperty"))
+        _ = bind(DummyMeasurement0(), spec.get_property("DummyProperty"))
 
 
 def test_collect_empty_fail():
     # Collect on empty collection with `strict = True` should fail
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     with pytest.raises(RuntimeError):
-        _ = suite.collect()
+        _ = spec.collect()
 
 
 def test_collect_empty_success():
     # Collect on empty collection with `strict = False` should succeed
-    suite = Suite("MySuite", DummyProperty())
-    _ = suite.collect(strict=False)
+    spec = Spec("MySpec", DummyProperty())
+    _ = spec.collect(strict=False)
 
 
 def test_collect_bound_success():
     # Collect with bound measurement should succeed
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     valid = bind(
         DummyMeasurement0().with_validator(
             Validator("MyValidator", lambda _: Success())
         ),
-        suite.get_property("DummyProperty"),
+        spec.get_property("DummyProperty"),
     )
-    _ = suite.collect(*valid.validate(True))
+    _ = spec.collect(*valid.validate(True))
 
 
 def test_collect_unbound_failure():
     # Collect with unbound measurement should fail
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     valid = DummyMeasurement0().with_validator(
         Validator("MyValidator", lambda _: Success())
     )
     with pytest.raises(RuntimeError):
-        _ = suite.collect(*valid.validate(True))
+        _ = spec.collect(*valid.validate(True))
 
 
 def test_collect_bound_failure():
     # Collect with measurement bound to
     # missing property should fail
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     valid = bind(
         DummyMeasurement0().with_validator(
             Validator("MyValidator", lambda _: Success())
@@ -114,12 +114,12 @@ def test_collect_bound_failure():
         "DummyPropertyFoo",
     )
     with pytest.raises(RuntimeError):
-        _ = suite.collect(*valid.validate(True))
+        _ = spec.collect(*valid.validate(True))
 
 
 def test_collect_unique():
     # Collect with duplicated results should fail
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     m0 = bind(
         DummyMeasurement0().with_validator(
             Validator("MyValidator", lambda _: Success())
@@ -132,12 +132,12 @@ def test_collect_unique():
         ),
         "DummyProperty",
     )
-    _ = suite.collect(*(*m0.validate(True), *m1.validate(True)))
+    _ = spec.collect(*(*m0.validate(True), *m1.validate(True)))
 
 
 def test_collect_duplicates():
     # Collect with duplicated results should fail
-    suite = Suite("MySuite", DummyProperty())
+    spec = Spec("MySpec", DummyProperty())
     m0 = bind(
         DummyMeasurement0().with_validator(
             Validator("MyValidator", lambda _: Success())
@@ -151,4 +151,4 @@ def test_collect_duplicates():
         "DummyProperty",
     )
     with pytest.raises(RuntimeError):
-        _ = suite.collect(*(*m0.validate(True), *m1.validate(True)))
+        _ = spec.collect(*(*m0.validate(True), *m1.validate(True)))


### PR DESCRIPTION
This PR accomplishes our terminology change from "suite" to "specification" to describe the mechanism that organizes properties into a coherent document. Within the `mlte` implementation, this entails refactoring the `Suite` type to the `Spec` type. This type is used in a wide variety of locations throughout the codebase, so this PR has a relatively-large blast radius. However, the functionality remains exactly the same (for now).

Resolves #59.