### PR TITLE
Feature/generic measurements

### DIFF
--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -91,9 +91,7 @@
     "    clf = tree.DecisionTreeClassifier()\n",
     "    clf.fit(X_train.to_numpy(), y_train.to_numpy())\n",
     "    with (MODELS_DIR / \"model.pkl\").open(\"wb\") as f:\n",
-    "        pickle.dump(clf, f)\n",
-    "\n",
-    "train_model()"
+    "        pickle.dump(clf, f)"
    ]
   },
   {
@@ -105,7 +103,10 @@
     "# Save the training dataset for use by training procedure\n",
     "X_train, _, y_train, _ = load_data()\n",
     "X_train.to_csv(DATASETS_DIR / \"data.csv\")\n",
-    "y_train.to_csv(DATASETS_DIR / \"target.csv\")"
+    "y_train.to_csv(DATASETS_DIR / \"target.csv\")\n",
+    "\n",
+    "# Train and save the model.\n",
+    "train_model()"
    ]
   },
   {
@@ -307,9 +308,7 @@
     "    \"\"\"Load a trained model.\"\"\"\n",
     "    path = MODELS_DIR / \"model.pkl\"\n",
     "    with path.open(\"rb\") as f:\n",
-    "        return pickle.load(f)\n",
-    "\n",
-    "train_model()"
+    "        return pickle.load(f)\n"
    ]
   },
   {
@@ -345,13 +344,11 @@
     "from sklearn.metrics import accuracy_score\n",
     "\n",
     "from mlte.measurement.result import Real\n",
-    "from mlte.measurement import MeasurementMetadata, Identifier\n",
+    "from mlte.measurement import ExternalMeasurement\n",
     "\n",
     "# Evaluate performance\n",
-    "accuracy = Real(\n",
-    "    MeasurementMetadata(\"accuracy_score\", Identifier(\"accuracy\")),\n",
-    "    accuracy_score(y_test, y_pred)\n",
-    ")\n",
+    "accuracy_measurement = ExternalMeasurement(\"accuracy\", Real)\n",
+    "accuracy = accuracy_measurement.evaluate(accuracy_score(y_test, y_pred))\n",
     "\n",
     "# Inspect result\n",
     "print(accuracy)\n",
@@ -375,14 +372,12 @@
    "outputs": [],
    "source": [
     "from sklearn.metrics import confusion_matrix\n",
-    "from mlte.measurement import MeasurementMetadata, Identifier\n",
     "from confusion_matrix import ConfusionMatrix\n",
+    "from mlte.measurement import ExternalMeasurement\n",
     "\n",
     "# Generate result\n",
-    "matrix = ConfusionMatrix(\n",
-    "    MeasurementMetadata(\"confusion_matrix\", Identifier(\"confusion matrix\")),\n",
-    "    confusion_matrix(y_test, y_pred)\n",
-    ")\n",
+    "matrix_measurement = ExternalMeasurement(\"confusion matrix\", ConfusionMatrix)\n",
+    "matrix = matrix_measurement.evaluate(confusion_matrix(y_test, y_pred))\n",
     "\n",
     "# Inspect\n",
     "print(matrix)\n",
@@ -407,6 +402,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "from mlte.measurement import MeasurementMetadata, Identifier\n",
     "from mlte.measurement.result import Image\n",
     "\n",
     "x = [\"Setosa\", \"Versicolour\", \"Virginica\"]\n",
@@ -425,13 +421,6 @@
     ")\n",
     "img.save()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -69,7 +69,6 @@
     "import pickle\n",
     "from typing import Tuple\n",
     "\n",
-    "import numpy as np\n",
     "import pandas as pd\n",
     "from sklearn.datasets import load_iris\n",
     "from sklearn.model_selection import train_test_split\n",
@@ -84,14 +83,18 @@
     "    X, y = iris.data, iris.target\n",
     "    return train_test_split(X, y, test_size=0.2)\n",
     "\n",
-    "def train_model():\n",
+    "def train_model(X_train, y_train):\n",
     "    \"\"\"Train a classifier and save.\"\"\"\n",
-    "    X_train, _, y_train, _ = load_data()\n",
-    "\n",
     "    clf = tree.DecisionTreeClassifier()\n",
     "    clf.fit(X_train.to_numpy(), y_train.to_numpy())\n",
-    "    with (MODELS_DIR / \"model.pkl\").open(\"wb\") as f:\n",
-    "        pickle.dump(clf, f)"
+    "    with (MODELS_DIR / \"model_demo.pkl\").open(\"wb\") as f:\n",
+    "        pickle.dump(clf, f)\n",
+    "\n",
+    "def load_model():\n",
+    "    \"\"\"Load a trained model.\"\"\"\n",
+    "    path = MODELS_DIR / \"model_demo.pkl\"\n",
+    "    with path.open(\"rb\") as f:\n",
+    "        return pickle.load(f)        "
    ]
   },
   {
@@ -106,7 +109,7 @@
     "y_train.to_csv(DATASETS_DIR / \"target.csv\")\n",
     "\n",
     "# Train and save the model.\n",
-    "train_model()"
+    "train_model(X_train, y_train)"
    ]
   },
   {
@@ -293,22 +296,6 @@
     "#### Task Efficacy Measurements\n",
     "\n",
     "Evidence collected in this section demonstrates MLTE's flexibility in handling inputs from external libraries and in different media types."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pickle\n",
-    "from sklearn import tree\n",
-    "\n",
-    "def load_model():\n",
-    "    \"\"\"Load a trained model.\"\"\"\n",
-    "    path = MODELS_DIR / \"model.pkl\"\n",
-    "    with path.open(\"rb\") as f:\n",
-    "        return pickle.load(f)\n"
    ]
   },
   {

--- a/docs/source/evidence.md
+++ b/docs/source/evidence.md
@@ -64,19 +64,17 @@ size.save()
 ```
 
 ## Ingest External Functionality
-Users can wrap the output of external measurements in a suitable Result type to integrate them into MLTE. In the following example, we wrap the output from the accuracy score function from [scikit learn](https://scikit-learn.org/stable/modules/model_evaluation.html#accuracy-score) with a built in MLTE type (Real) to integrate it with our collection of evidence. The Real Result instance is then persisted to the MLTE artifact store.
+Users can wrap the output of external measurements in a suitable Result type to integrate them into MLTE. In the following example, we wrap the output from the accuracy score function from [scikit learn](https://scikit-learn.org/stable/modules/model_evaluation.html#accuracy-score) with a built in MLTE type (Real) to integrate it with our collection of evidence, by using ExternalMeasurement. The Real Result instance is then persisted to the MLTE artifact store.
 
 ```Python
 from sklearn.metrics import accuracy_score
 
 from mlte.measurement.result import Real
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement import ExternalMeasurement
 
 # Evaluate performance
-accuracy = Real(
-    MeasurementMetadata("accuracy_score", Identifier("accuracy")),
-    accuracy_score(y_test, y_pred)
-)
+accuracy_measurement = ExternalMeasurement("accuracy", Real)
+accuracy = accuracy_measurement.evaluate(accuracy_score(y_test, y_pred))
 
 # Inspect result
 print(accuracy)
@@ -90,14 +88,12 @@ Here, we define a custom Result type to cope with the output of a third-party li
 
 ```Python
 from sklearn.metrics import confusion_matrix
-from mlte.measurement import MeasurementMetadata, Identifier
 from confusion_matrix import ConfusionMatrix
+from mlte.measurement import ExternalMeasurement
 
 # Generate result
-matrix = ConfusionMatrix(
-    MeasurementMetadata("confusion_matrix", Identifier("confusion matrix")),
-    confusion_matrix(y_test, y_pred)
-)
+matrix_measurement = ExternalMeasurement("confusion matrix", ConfusionMatrix)
+matrix = matrix_measurement.evaluate(confusion_matrix(y_test, y_pred))
 
 # Inspect
 print(matrix)

--- a/docs/source/extending_mlte.md
+++ b/docs/source/extending_mlte.md
@@ -8,13 +8,11 @@ If you are looking to use your own functions or those from another library (such
 from sklearn.metrics import accuracy_score
 
 from mlte.measurement.result import Real
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement import ExternalMeasurement
 
 # Evaluate performance
-accuracy = Real(
-    MeasurementMetadata("accuracy_score", Identifier("accuracy")),
-    accuracy_score(y_test, y_pred)
-)
+accuracy_measurement = ExternalMeasurement("accuracy", Real)
+accuracy = accuracy_measurement.evaluate(accuracy_score(y_test, y_pred))
 
 # Inspect result
 print(accuracy)
@@ -33,14 +31,12 @@ See below for an example of how to write a MLTE result type, regardless of wheth
 
 ```Python
 from sklearn.metrics import confusion_matrix
-from mlte.measurement import MeasurementMetadata, Identifier
 from confusion_matrix import ConfusionMatrix
+from mlte.measurement import ExternalMeasurement
 
 # Generate result
-matrix = ConfusionMatrix(
-    MeasurementMetadata("confusion_matrix", Identifier("confusion matrix")),
-    confusion_matrix(y_test, y_pred)
-)
+matrix_measurement = ExternalMeasurement("confusion matrix", ConfusionMatrix)
+matrix = matrix_measurement.evaluate(confusion_matrix(y_test, y_pred))
 
 # Inspect
 print(matrix)

--- a/src/mlte/measurement/__init__.py
+++ b/src/mlte/measurement/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "MeasurementMetadata",
     "Identifier",
     "ProcessMeasurement",
-    "ExternalMeasurement"
+    "ExternalMeasurement",
 ]

--- a/src/mlte/measurement/__init__.py
+++ b/src/mlte/measurement/__init__.py
@@ -2,10 +2,12 @@ from .measurement import Measurement
 from .measurement_metadata import MeasurementMetadata
 from .identifier import Identifier
 from .process_measurement import ProcessMeasurement
+from .external_measurement import ExternalMeasurement
 
 __all__ = [
     "Measurement",
     "MeasurementMetadata",
     "Identifier",
     "ProcessMeasurement",
+    "ExternalMeasurement"
 ]

--- a/src/mlte/measurement/external_measurement.py
+++ b/src/mlte/measurement/external_measurement.py
@@ -1,23 +1,31 @@
-from typing import Type
+"""
+Base class for measurements calculated by external functions.
+"""
+
+from __future__ import annotations
 
 from .result import Result
 from .measurement import Measurement
 
 
 class ExternalMeasurement(Measurement):
-
-    def __init__(self, identifier: str, result_type: Type):
+    def __init__(self, identifier: str, result_type: type):
         """
         Initialize a new ExternalMeasurement measurement.
 
         :param identifier: A unique identifier for the instance
         :type identifier: str
         :param result_type: The type of the Result this measurement will return.
-        :type result_type: Type        
+        :type result_type: Type
         """
         super().__init__(self, identifier)
-        self.result_type: Type = result_type
-    
+        if not issubclass(Result, result_type):
+            raise Exception(
+                f"Result type provided is not a subtype of Result: {self.result_type}"
+            )
+        self.result_type: type = result_type       
+
     def __call__(self, *args, **kwargs) -> Result:
         """Evaluate a measurement and return results without semantics."""
-        return self.result_type(self.metadata, *args, **kwargs)
+        result: Result = self.result_type(self.metadata, *args, **kwargs)
+        return result

--- a/src/mlte/measurement/external_measurement.py
+++ b/src/mlte/measurement/external_measurement.py
@@ -23,7 +23,7 @@ class ExternalMeasurement(Measurement):
             raise Exception(
                 f"Result type provided is not a subtype of Result: {self.result_type}"
             )
-        self.result_type: type = result_type       
+        self.result_type: type = result_type
 
     def __call__(self, *args, **kwargs) -> Result:
         """Evaluate a measurement and return results without semantics."""

--- a/src/mlte/measurement/external_measurement.py
+++ b/src/mlte/measurement/external_measurement.py
@@ -1,0 +1,23 @@
+from typing import Type
+
+from .result import Result
+from .measurement import Measurement
+
+
+class ExternalMeasurement(Measurement):
+
+    def __init__(self, identifier: str, result_type: Type):
+        """
+        Initialize a new ExternalMeasurement measurement.
+
+        :param identifier: A unique identifier for the instance
+        :type identifier: str
+        :param result_type: The type of the Result this measurement will return.
+        :type result_type: Type        
+        """
+        super().__init__(self, identifier)
+        self.result_type: Type = result_type
+    
+    def __call__(self, *args, **kwargs) -> Result:
+        """Evaluate a measurement and return results without semantics."""
+        return self.result_type(self.metadata, *args, **kwargs)

--- a/test/measurement/test_external_measurement.py
+++ b/test/measurement/test_external_measurement.py
@@ -1,0 +1,46 @@
+"""
+Unit test for ExternalMeasurement.
+"""
+import pytest
+
+from mlte.measurement.result import Integer
+from mlte.measurement import (
+    MeasurementMetadata,
+    Identifier,
+    ExternalMeasurement,
+)
+
+
+def _dummy_calculation(x: int, y: int):
+    """
+    Dummy calculation function that adds two ints and multiplies the result by two.
+
+    :param x: The first number
+    :type x: int
+    :param y: The second number
+    :type y: int
+
+    :return: the result of the calculation
+    :rtype: int
+    """
+    return (x + y) * 2
+
+
+def test_evaluate_external():
+    x = 1
+    y = 2
+    expected_value = _dummy_calculation(x, y)
+    expected_result = Integer(
+        MeasurementMetadata("dummy", Identifier("test")), expected_value
+    )
+
+    measurement = ExternalMeasurement("dummy", Integer)
+    result = measurement.evaluate(_dummy_calculation(x, y))
+
+    assert isinstance(result, Integer)
+    assert result == expected_result
+
+
+def test_invalid_result_type():
+    with pytest.raises(Exception):
+        ExternalMeasurement("dummy", int)


### PR DESCRIPTION
 * Added ExternalMeasurement measurement type, used to wrap external measurements by ensuring the return type is a Result type passed in the constructor, and allowing the use of evaluate() in a similar way to other measurements, only just wrapping the external function call.
 * Updated demo and docs to show use of ExternalMeasurement.
 * Very minor cleanup to evidence demo to run train_model() in a more efficient location (and more easily avoid re-calling it when not needed).