### PR TITLE
Bugfix/artifact path spaces

### DIFF
--- a/src/mlte/store/api/local/api.py
+++ b/src/mlte/store/api/local/api.py
@@ -100,10 +100,9 @@ def _result_path(model_version_path: Path, result_identifier: str) -> Path:
     :return: The formatted result path
     :rtype: Path
     """
-    path = (
+    return (
         model_version_path / result_identifier.replace(" ", "-")
     ).with_suffix(".json")
-    return Path(str(path))
 
 
 def _spec_is_saved(model_version_path: Path) -> bool:

--- a/src/mlte/store/api/local/api.py
+++ b/src/mlte/store/api/local/api.py
@@ -182,7 +182,7 @@ def _write_binding(model_version_path: Path, data: Dict[str, Any]):
     """
     binding_path = model_version_path / BINDING_FILENAME
     with open(binding_path, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=4)
 
 
 # -----------------------------------------------------------------------------
@@ -219,7 +219,7 @@ def _write_spec(model_version_path: Path, data: Dict[str, Any]):
     """
     spec_path = model_version_path / SPEC_FILENAME
     with open(spec_path, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=4)
 
 
 # -----------------------------------------------------------------------------
@@ -256,7 +256,7 @@ def _write_boundspec(model_version_path: Path, data: Dict[str, Any]):
     """
     spec_path = model_version_path / BOUNDSPEC_FILENAME
     with open(spec_path, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=4)
 
 
 # -----------------------------------------------------------------------------
@@ -324,10 +324,10 @@ def _write_result(result_path: Path, result: Result, tag: Optional[str]):
 
         # Persist updates
         with result_path.open("w") as f:
-            json.dump(mutating.to_json(), f)
+            json.dump(mutating.to_json(), f, indent=4)
     else:
         with result_path.open("w") as f:
-            json.dump(result.to_json(), f)
+            json.dump(result.to_json(), f, indent=4)
 
 
 # -----------------------------------------------------------------------------

--- a/src/mlte/store/api/local/api.py
+++ b/src/mlte/store/api/local/api.py
@@ -88,7 +88,7 @@ def _available_result_versions(result_path: Path) -> Set[int]:
         return set(e["version"] for e in document["versions"])
 
 
-def _result_path(model_version_path: Path, result_identifier: str):
+def _result_path(model_version_path: Path, result_identifier: str) -> Path:
     """
     Form the result path from model version path and result identifier.
 
@@ -100,8 +100,10 @@ def _result_path(model_version_path: Path, result_identifier: str):
     :return: The formatted result path
     :rtype: Path
     """
-    path = (model_version_path / result_identifier).with_suffix(".json")
-    return Path(str(path).replace(" ", "-"))
+    path = (
+        model_version_path / result_identifier.replace(" ", "-")
+    ).with_suffix(".json")
+    return Path(str(path))
 
 
 def _spec_is_saved(model_version_path: Path) -> bool:


### PR DESCRIPTION
* Fixes issue #114 where spaces in path were being replaced by hyphens, thus breaking access to a path in the artifact store. Now only the name of the file for an artifact has its spaces replaced by hyphen, which was the original intention.
* Added indentation to serialized JSON files in store, to make them more human readable.