### PR TITLE
Refactoring and external results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ demo/models
 demo/store
 demo/media
 demo/reports
+
+# VS Code local configs.
+.vscode/

--- a/demo/confusion_matrix.py
+++ b/demo/confusion_matrix.py
@@ -8,7 +8,7 @@ from typing import Dict, Any
 import numpy as np
 
 from mlte.measurement.result import Result
-from mlte.measurement import MeasurementMetadata
+from mlte.measurement.measurement_metadata import MeasurementMetadata
 from mlte.measurement.validation import (
     Validator,
     ValidationResult,

--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -403,7 +403,7 @@
     "plt.savefig(MEDIA_DIR / \"classes.png\")\n",
     "\n",
     "img_collector = ExternalMeasurement(\"class distribution\", Image)\n",
-    "img = img_collector.collect_data(MEDIA_DIR / \"classes.png\")\n",
+    "img = img_collector.ingest(MEDIA_DIR / \"classes.png\")\n",
     "\n",
     "img.save()"
    ]

--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -389,7 +389,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from mlte.measurement import MeasurementMetadata, Identifier\n",
+    "from mlte.measurement import ExternalMeasurement\n",
     "from mlte.measurement.result import Image\n",
     "\n",
     "x = [\"Setosa\", \"Versicolour\", \"Virginica\"]\n",
@@ -402,10 +402,9 @@
     "plt.ylabel(\"Occurrences\")\n",
     "plt.savefig(MEDIA_DIR / \"classes.png\")\n",
     "\n",
-    "img = Image(\n",
-    "    MeasurementMetadata(\"plt.bar\", Identifier(\"class distribution\")),\n",
-    "    MEDIA_DIR / \"classes.png\"\n",
-    ")\n",
+    "img_collector = ExternalMeasurement(\"class distribution\", Image)\n",
+    "img = img_collector.collect_data(MEDIA_DIR / \"classes.png\")\n",
+    "\n",
     "img.save()"
    ]
   }

--- a/src/mlte/_global/state.py
+++ b/src/mlte/_global/state.py
@@ -50,6 +50,20 @@ class GlobalState:
         assert self.has_artifact_store_uri(), "Broken precondition."
         return self.artifact_store_uri
 
+    def check(self):
+        """
+        Ensure that the global state contains
+        information necessary to save/load artifacts.
+        """
+        if not self.has_model():
+            raise RuntimeError(
+                "Set model context prior to saving or loading artifacts."
+            )
+        if not self.has_artifact_store_uri():
+            raise RuntimeError(
+                "Set artifact store URI prior to saving or loading artifacts."
+            )
+
 
 # Singleton global state
 g_state = GlobalState()

--- a/src/mlte/_global/state.py
+++ b/src/mlte/_global/state.py
@@ -50,7 +50,7 @@ class GlobalState:
         assert self.has_artifact_store_uri(), "Broken precondition."
         return self.artifact_store_uri
 
-    def check(self):
+    def ensure_initialized(self):
         """
         Ensure that the global state contains
         information necessary to save/load artifacts.

--- a/src/mlte/binding/binding.py
+++ b/src/mlte/binding/binding.py
@@ -6,20 +6,9 @@ from __future__ import annotations
 from typing import Dict, List, Any
 
 
-from mlte._global import global_state, GlobalState
+from mlte._global import global_state
 from mlte.store.api import read_binding, write_binding
 from mlte._private.schema import BINDING_LATEST_SCHEMA_VERSION
-
-
-def _check_global_state(state: GlobalState):
-    """
-    Ensure that the global state contains
-    information necessary to save/load results.
-    """
-    if not state.has_model():
-        raise RuntimeError("Set model context prior to saving result.")
-    if not state.has_artifact_store_uri():
-        raise RuntimeError("Set artifact store URI prior to saving result.")
 
 
 def _verify_integrity(description: Dict[str, List[str]]):
@@ -79,7 +68,7 @@ class Binding:
     def save(self):
         """Save the Binding instance to artifact store."""
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -101,7 +90,7 @@ class Binding:
         :rtype: Binding
         """
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/binding/binding.py
+++ b/src/mlte/binding/binding.py
@@ -68,7 +68,7 @@ class Binding:
     def save(self):
         """Save the Binding instance to artifact store."""
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -90,7 +90,7 @@ class Binding:
         :rtype: Binding
         """
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/measurement/__init__.py
+++ b/src/mlte/measurement/__init__.py
@@ -1,13 +1,9 @@
 from .measurement import Measurement
-from .measurement_metadata import MeasurementMetadata
-from .identifier import Identifier
 from .process_measurement import ProcessMeasurement
 from .external_measurement import ExternalMeasurement
 
 __all__ = [
     "Measurement",
-    "MeasurementMetadata",
-    "Identifier",
     "ProcessMeasurement",
     "ExternalMeasurement",
 ]

--- a/src/mlte/measurement/cpu/local_process_cpu_utilization.py
+++ b/src/mlte/measurement/cpu/local_process_cpu_utilization.py
@@ -9,7 +9,8 @@ import subprocess
 from typing import Dict, Any
 from subprocess import SubprocessError
 
-from mlte.measurement import ProcessMeasurement, MeasurementMetadata
+from ..process_measurement import ProcessMeasurement
+from ..measurement_metadata import MeasurementMetadata
 from mlte.measurement.result import Result
 from mlte.measurement.validation import (
     Validator,

--- a/src/mlte/measurement/external_measurement.py
+++ b/src/mlte/measurement/external_measurement.py
@@ -30,7 +30,7 @@ class ExternalMeasurement(Measurement):
         result: Result = self.result_type(self.metadata, *args, **kwargs)
         return result
 
-    def collect_data(self, *args, **kwargs) -> Result:
-        """Collect data without evaluating a function. Currently works the same as evaluate()."""
+    def ingest(self, *args, **kwargs) -> Result:
+        """Ingest data without evaluating a function, to wrap it as the configured Result type. Currently works the same as evaluate()."""
         result: Result = self.result_type(self.metadata, *args, **kwargs)
         return result

--- a/src/mlte/measurement/external_measurement.py
+++ b/src/mlte/measurement/external_measurement.py
@@ -29,3 +29,8 @@ class ExternalMeasurement(Measurement):
         """Evaluate a measurement and return results without semantics."""
         result: Result = self.result_type(self.metadata, *args, **kwargs)
         return result
+
+    def collect_data(self, *args, **kwargs) -> Result:
+        """Collect data without evaluating a function. Currently works the same as evaluate()."""
+        result: Result = self.result_type(self.metadata, *args, **kwargs)
+        return result

--- a/src/mlte/measurement/memory/local_process_memory_consumption.py
+++ b/src/mlte/measurement/memory/local_process_memory_consumption.py
@@ -8,7 +8,8 @@ import time
 import subprocess
 from typing import Dict, Any
 
-from mlte.measurement import ProcessMeasurement, MeasurementMetadata
+from ..process_measurement import ProcessMeasurement
+from ..measurement_metadata import MeasurementMetadata
 from mlte.measurement.result import Result
 from mlte.measurement.validation import (
     Validator,

--- a/src/mlte/measurement/result/result.py
+++ b/src/mlte/measurement/result/result.py
@@ -7,7 +7,7 @@ import abc
 
 from typing import Dict, Any, Optional
 
-from mlte._global import global_state, GlobalState
+from mlte._global import global_state
 from mlte.store.api import read_result, write_result
 from mlte.measurement.identifier import Identifier
 from mlte._private.schema import RESULT_LATEST_SCHEMA_VERSION
@@ -21,17 +21,6 @@ from ..measurement_metadata import MeasurementMetadata
 def _has_callable(type, name) -> bool:
     """Determine if `type` has a callable attribute with the given name."""
     return hasattr(type, name) and callable(getattr(type, name))
-
-
-def _check_global_state(state: GlobalState):
-    """
-    Ensure that the global state contains
-    information necessary to save/load results.
-    """
-    if not state.has_model():
-        raise RuntimeError("Set model context prior to saving result.")
-    if not state.has_artifact_store_uri():
-        raise RuntimeError("Set artifact store URI prior to saving result.")
 
 
 class Result(metaclass=abc.ABCMeta):
@@ -92,7 +81,7 @@ class Result(metaclass=abc.ABCMeta):
         :type tag: str
         """
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -128,7 +117,7 @@ class Result(metaclass=abc.ABCMeta):
         :rtype: Result
         """
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/measurement/result/result.py
+++ b/src/mlte/measurement/result/result.py
@@ -81,7 +81,7 @@ class Result(metaclass=abc.ABCMeta):
         :type tag: str
         """
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -117,7 +117,7 @@ class Result(metaclass=abc.ABCMeta):
         :rtype: Result
         """
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/spec/bound_spec.py
+++ b/src/mlte/spec/bound_spec.py
@@ -34,7 +34,7 @@ class BoundSpec:
     def save(self):
         """Save BoundSpec instance to artifact store."""
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -51,7 +51,7 @@ class BoundSpec:
         :rtype: BoundSpec
         """
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/spec/bound_spec.py
+++ b/src/mlte/spec/bound_spec.py
@@ -6,19 +6,8 @@ from __future__ import annotations
 
 from typing import Dict, Any
 
-from mlte._global import global_state, GlobalState
+from mlte._global import global_state
 from mlte.store.api import read_boundspec, write_boundspec
-
-
-def _check_global_state(state: GlobalState):
-    """
-    Ensure that the global state contains
-    information necessary to save/load results.
-    """
-    if not state.has_model():
-        raise RuntimeError("Set model context prior to saving result.")
-    if not state.has_artifact_store_uri():
-        raise RuntimeError("Set artifact store URI prior to saving result.")
 
 
 # -----------------------------------------------------------------------------
@@ -45,7 +34,7 @@ class BoundSpec:
     def save(self):
         """Save BoundSpec instance to artifact store."""
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -62,7 +51,7 @@ class BoundSpec:
         :rtype: BoundSpec
         """
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/spec/spec.py
+++ b/src/mlte/spec/spec.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Iterable, Any, Union
 from mlte.property import Property
 from mlte.measurement.validation import ValidationResult
 from mlte._private.schema import SPEC_LATEST_SCHEMA_VERSION
-from mlte._global import global_state, GlobalState
+from mlte._global import global_state
 from mlte.store.api import read_spec, write_spec
 from mlte.binding import Binding
 from .bound_spec import BoundSpec
@@ -42,17 +42,6 @@ def _all_equal(iterable: Iterable[Any]) -> bool:
     """
     g = groupby(iterable)
     return next(g, True) and not next(g, False)  # type: ignore
-
-
-def _check_global_state(state: GlobalState):
-    """
-    Ensure that the global state contains
-    information necessary to save/load results.
-    """
-    if not state.has_model():
-        raise RuntimeError("Set model context prior to saving result.")
-    if not state.has_artifact_store_uri():
-        raise RuntimeError("Set artifact store URI prior to saving result.")
 
 
 # -----------------------------------------------------------------------------
@@ -106,7 +95,7 @@ class Spec:
     def save(self):
         """Persist the specification to artifact store."""
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -128,7 +117,7 @@ class Spec:
         :rtype: Spec
         """
         state = global_state()
-        _check_global_state(state)
+        state.check()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/spec/spec.py
+++ b/src/mlte/spec/spec.py
@@ -95,7 +95,7 @@ class Spec:
     def save(self):
         """Persist the specification to artifact store."""
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()
@@ -117,7 +117,7 @@ class Spec:
         :rtype: Spec
         """
         state = global_state()
-        state.check()
+        state.ensure_initialized()
 
         model_identifier, model_version = state.get_model()
         artifact_store_uri = state.get_artifact_store_uri()

--- a/src/mlte/store/api/local/api.py
+++ b/src/mlte/store/api/local/api.py
@@ -148,21 +148,23 @@ def _boundspec_is_saved(model_version_path: Path) -> bool:
 
 
 # -----------------------------------------------------------------------------
-# Read / Write Binding
+# Read / Write, for general artifacts.
 # -----------------------------------------------------------------------------
 
 
-def _read_binding(model_version_path: Path) -> Dict[str, Any]:
+def _read_artifact(model_version_path: Path, filename: str) -> Dict[str, Any]:
     """
-    Read binding data for model version.
+    Read artifact data for model version.
 
     :param model_version_path: The path to the model version
     :type model_version_path: Path
+    :param filename: The file name
+    :type filename: str
 
     :return: The binding data
     :rtype: Dict[str, Any]
     """
-    binding_path = model_version_path / BINDING_FILENAME
+    binding_path = model_version_path / filename
     assert binding_path.is_file(), "Broken invariant."
 
     with open(binding_path, "r") as f:
@@ -170,91 +172,21 @@ def _read_binding(model_version_path: Path) -> Dict[str, Any]:
         return result
 
 
-def _write_binding(model_version_path: Path, data: Dict[str, Any]):
+def _write_artifact(
+    model_version_path: Path, filename: str, data: Dict[str, Any]
+):
     """
-    Write binding data for model version.
+    Write artifact data for model version.
 
     :param model_version_path: The path to the model version
     :type model_version_path: Path
+    :param filename: The file name
+    :type filename: str
     :param data: The binding data
     :type data: Dict[str, Any]
     """
-    binding_path = model_version_path / BINDING_FILENAME
+    binding_path = model_version_path / filename
     with open(binding_path, "w") as f:
-        json.dump(data, f, indent=4)
-
-
-# -----------------------------------------------------------------------------
-# Read / Write Spec
-# -----------------------------------------------------------------------------
-
-
-def _read_spec(model_version_path: Path) -> Dict[str, Any]:
-    """
-    Read specification data for model version.
-
-    :param model_version_path: The path to the model version
-    :type model_version_path: Path
-
-    :return: The specification data
-    :rtype: Dict[str, Any]
-    """
-    spec_path = model_version_path / SPEC_FILENAME
-    assert spec_path.is_file(), "Broken invariant."
-
-    with open(spec_path, "r") as f:
-        result: Dict[str, Any] = json.load(f)
-        return result
-
-
-def _write_spec(model_version_path: Path, data: Dict[str, Any]):
-    """
-    Write specification data for model version.
-
-    :param model_version_path: The path to the model version
-    :type model_version_path: Path
-    :param data: The specification data
-    :type data: Dict[str, Any]
-    """
-    spec_path = model_version_path / SPEC_FILENAME
-    with open(spec_path, "w") as f:
-        json.dump(data, f, indent=4)
-
-
-# -----------------------------------------------------------------------------
-# Read / Write BoundSpec
-# -----------------------------------------------------------------------------
-
-
-def _read_boundspec(model_version_path: Path) -> Dict[str, Any]:
-    """
-    Read bound specification data for model version.
-
-    :param model_version_path: The path to the model version
-    :type model_version_path: Path
-
-    :return: The bound specification data
-    :rtype: Dict[str, Any]
-    """
-    spec_path = model_version_path / BOUNDSPEC_FILENAME
-    assert spec_path.is_file(), "Broken invariant."
-
-    with open(spec_path, "r") as f:
-        result: Dict[str, Any] = json.load(f)
-        return result
-
-
-def _write_boundspec(model_version_path: Path, data: Dict[str, Any]):
-    """
-    Write bound specification data for model version.
-
-    :param model_version_path: The path to the model version
-    :type model_version_path: Path
-    :param data: The specification data
-    :type data: Dict[str, Any]
-    """
-    spec_path = model_version_path / BOUNDSPEC_FILENAME
-    with open(spec_path, "w") as f:
         json.dump(data, f, indent=4)
 
 
@@ -420,7 +352,7 @@ def read_binding(
     if not _binding_is_saved(model_version_path):
         raise RuntimeError("Failed to read binding, no binding is saved.")
 
-    return _read_binding(model_version_path)
+    return _read_artifact(model_version_path, BINDING_FILENAME)
 
 
 def write_binding(
@@ -441,7 +373,7 @@ def write_binding(
         version_path.mkdir()
 
     model_version_path = root / model_identifier / model_version
-    _write_binding(model_version_path, data)
+    _write_artifact(model_version_path, BINDING_FILENAME, data)
 
 
 def read_spec(
@@ -459,7 +391,7 @@ def read_spec(
     if not _spec_is_saved(model_version_path):
         raise RuntimeError("Failed to read binding, no binding is saved.")
 
-    return _read_spec(model_version_path)
+    return _read_artifact(model_version_path, SPEC_FILENAME)
 
 
 def write_spec(
@@ -480,7 +412,7 @@ def write_spec(
         version_path.mkdir()
 
     model_version_path = root / model_identifier / model_version
-    _write_spec(model_version_path, data)
+    _write_artifact(model_version_path, SPEC_FILENAME, data)
 
 
 def read_boundspec(
@@ -498,7 +430,7 @@ def read_boundspec(
     if not _boundspec_is_saved(model_version_path):
         raise RuntimeError("Failed to read binding, no binding is saved.")
 
-    return _read_boundspec(model_version_path)
+    return _read_artifact(model_version_path, BOUNDSPEC_FILENAME)
 
 
 def write_boundspec(
@@ -519,7 +451,7 @@ def write_boundspec(
         version_path.mkdir()
 
     model_version_path = root / model_identifier / model_version
-    _write_boundspec(model_version_path, data)
+    _write_artifact(model_version_path, BOUNDSPEC_FILENAME, data)
 
 
 # -----------------------------------------------------------------------------

--- a/test/measurement/result/test_image.py
+++ b/test/measurement/result/test_image.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import mlte
 import requests
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte.measurement.result import Image
 
 # A cute image for testing purposes

--- a/test/measurement/result/test_integer.py
+++ b/test/measurement/result/test_integer.py
@@ -5,7 +5,9 @@ Unit tests for Integer.
 import pytest
 
 import mlte
-from mlte.measurement import Measurement, MeasurementMetadata, Identifier
+from mlte.measurement import Measurement
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte.measurement.result import Integer
 
 

--- a/test/measurement/result/test_opaque.py
+++ b/test/measurement/result/test_opaque.py
@@ -5,7 +5,9 @@ Unit tests for Opaque.
 import pytest
 
 import mlte
-from mlte.measurement import Measurement, MeasurementMetadata, Identifier
+from mlte.measurement import Measurement
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte.measurement.result import Opaque
 
 

--- a/test/measurement/result/test_real.py
+++ b/test/measurement/result/test_real.py
@@ -5,7 +5,9 @@ Unit tests for Real.
 import pytest
 
 import mlte
-from mlte.measurement import Measurement, MeasurementMetadata, Identifier
+from mlte.measurement import Measurement
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte.measurement.result import Real
 
 

--- a/test/measurement/test_external_measurement.py
+++ b/test/measurement/test_external_measurement.py
@@ -39,14 +39,14 @@ def test_evaluate_external():
     assert result == expected_result
 
 
-def test_evaluate_collect_data():
+def test_evaluate_ingest():
     expected_value = 1000
     expected_result = Integer(
         MeasurementMetadata("dummy", Identifier("test")), expected_value
     )
 
     measurement = ExternalMeasurement("dummy", Integer)
-    result = measurement.collect_data(expected_value)
+    result = measurement.ingest(expected_value)
 
     assert isinstance(result, Integer)
     assert result == expected_result

--- a/test/measurement/test_external_measurement.py
+++ b/test/measurement/test_external_measurement.py
@@ -4,11 +4,9 @@ Unit test for ExternalMeasurement.
 import pytest
 
 from mlte.measurement.result import Integer
-from mlte.measurement import (
-    MeasurementMetadata,
-    Identifier,
-    ExternalMeasurement,
-)
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
+from mlte.measurement import ExternalMeasurement
 
 
 def _dummy_calculation(x: int, y: int):

--- a/test/measurement/test_external_measurement.py
+++ b/test/measurement/test_external_measurement.py
@@ -39,6 +39,19 @@ def test_evaluate_external():
     assert result == expected_result
 
 
+def test_evaluate_collect_data():
+    expected_value = 1000
+    expected_result = Integer(
+        MeasurementMetadata("dummy", Identifier("test")), expected_value
+    )
+
+    measurement = ExternalMeasurement("dummy", Integer)
+    result = measurement.collect_data(expected_value)
+
+    assert isinstance(result, Integer)
+    assert result == expected_result
+
+
 def test_invalid_result_type():
     with pytest.raises(Exception):
         ExternalMeasurement("dummy", int)

--- a/test/schema/test_boundspec_schema.py
+++ b/test/schema/test_boundspec_schema.py
@@ -7,7 +7,8 @@ from mlte.spec import Spec
 from mlte.binding import Binding
 from mlte.property.costs import StorageCost
 from mlte.measurement.result import Integer
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte.store.api import read_boundspec
 from mlte._private.schema import validate_boundspec_schema
 

--- a/test/schema/test_result_schema.py
+++ b/test/schema/test_result_schema.py
@@ -4,7 +4,8 @@ Unit tests for Result schema.
 
 import mlte
 from mlte.measurement.result import Integer, Real, Opaque
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 from mlte._private.schema import validate_result_schema
 from mlte.store.api import read_result
 

--- a/test/spec/test_boundspec.py
+++ b/test/spec/test_boundspec.py
@@ -7,7 +7,8 @@ from mlte.spec import Spec, BoundSpec
 from mlte.binding import Binding
 from mlte.property.costs import StorageCost
 from mlte.measurement.result import Integer
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 
 
 def test_save_load(tmp_path):

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -9,7 +9,8 @@ from mlte.spec import Spec
 from mlte.binding import Binding
 from mlte.property.costs import StorageCost
 from mlte.measurement.result import Integer
-from mlte.measurement import MeasurementMetadata, Identifier
+from mlte.measurement.measurement_metadata import MeasurementMetadata
+from mlte.measurement.identifier import Identifier
 
 
 def test_save(tmp_path):


### PR DESCRIPTION
* Fixes #128 by centralizing check() call as a method of GlobalState
* Fixes #127, refactored to have 1 common read/write artifact internal local api function.
* Fixes #117, making Identifier and MeasurementMetadata internal, adapting imports in tests, internal modules, and extended results to now load them from internal modules. 
* As part of #117, added ExternalMeasurement collect_data() method to create a result of a certain type when there is no function to call/evaluate. In practice, it currently the same as ExternalMeasurement's evaluate(), but it could differ in the future if evaluate() starts really executing the function it is measuring. The main goal of this method is to give the library user a clearer way to indicate it is just wrapping data in the result type provided to the ExternalMeasurement.