### PR TITLE
Simplifying addition of new properties

### DIFF
--- a/src/mlte/property/costs/storage_cost.py
+++ b/src/mlte/property/costs/storage_cost.py
@@ -25,7 +25,3 @@ class StorageCost(Property):
             ),
             rationale,
         )
-
-    def __repr__(self) -> str:
-        """Return the representation needed to reconstruct the object."""
-        return f"{self.name}()"

--- a/src/mlte/property/costs/training_compute_cost.py
+++ b/src/mlte/property/costs/training_compute_cost.py
@@ -30,7 +30,3 @@ class TrainingComputeCost(Property):
             ),
             rationale,
         )
-
-    def __repr__(self) -> str:
-        """Return the representation needed to reconstruct the object."""
-        return f"{self.name}()"

--- a/src/mlte/property/costs/training_memory_cost.py
+++ b/src/mlte/property/costs/training_memory_cost.py
@@ -30,7 +30,3 @@ class TrainingMemoryCost(Property):
             ),
             rationale,
         )
-
-    def __repr__(self) -> str:
-        """Return the representation needed to reconstruct the object."""
-        return f"{self.name}()"

--- a/src/mlte/property/functionality/task_efficacy.py
+++ b/src/mlte/property/functionality/task_efficacy.py
@@ -27,7 +27,3 @@ class TaskEfficacy(Property):
             ),
             rationale,
         )
-
-    def __repr__(self) -> str:
-        """Return the representation needed to reconstruct the object."""
-        return f"{self.name}()"

--- a/src/mlte/property/property.py
+++ b/src/mlte/property/property.py
@@ -112,14 +112,14 @@ def _load_from_document(document: dict[str, str]) -> Property:
     properties_module = importlib.import_module(
         properties_package_name, package="mlte"
     )
-    for subpackage_info in pkgutil.iter_modules(
+    for submodule_info in pkgutil.iter_modules(
         properties_module.__path__, properties_module.__name__ + "."
     ):
-        subpackage = importlib.import_module(
-            subpackage_info.name, package=properties_package_name
+        submodule = importlib.import_module(
+            submodule_info.name, package=properties_package_name
         )
         try:
-            class_: Type[Property] = getattr(subpackage, classname)
+            class_: Type[Property] = getattr(submodule, classname)
         except AttributeError:
             continue
 

--- a/src/mlte/property/property.py
+++ b/src/mlte/property/property.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 import abc
 import importlib
+import pkgutil
 from typing import Type
-
-# The names of the properties submodules
-SUBMODULES = ["costs", "functionality"]
 
 
 def _has_callable(type, name) -> bool:
@@ -73,6 +71,10 @@ class Property(metaclass=abc.ABCMeta):
         """
         return _load_from_document(document)
 
+    def __repr__(self) -> str:
+        """Return the representation needed to reconstruct the object."""
+        return f"{self.name}()"
+
 
 def _get_class_name(property_repr: str) -> str:
     """
@@ -106,12 +108,18 @@ def _load_from_document(document: dict[str, str]) -> Property:
     classname = _get_class_name(property_repr)
 
     # Load the class type from the module
-    for submodule in SUBMODULES:
-        module = importlib.import_module(
-            f".{submodule}", package="mlte.property"
+    properties_package_name = "mlte.property"
+    properties_module = importlib.import_module(
+        properties_package_name, package="mlte"
+    )
+    for subpackage_info in pkgutil.iter_modules(
+        properties_module.__path__, properties_module.__name__ + "."
+    ):
+        subpackage = importlib.import_module(
+            subpackage_info.name, package=properties_package_name
         )
         try:
-            class_: Type[Property] = getattr(module, classname)
+            class_: Type[Property] = getattr(subpackage, classname)
         except AttributeError:
             continue
 


### PR DESCRIPTION
Two minor changes:
 - __repr__ was moved to the base Property class, since it works there anyway, so creating a new Property does not require one to duplicate that function.
 - When loading a Property from a JSON file, removed hardcoded list of subpackages containing properties, and changed to use reflection to find all subpackages containing properties, to simplify the addition of properties in new subpackages.