### PR TITLE
Add paper to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/mlte-team/mlte/master/assets/MLTE_Logo_Color.svg" alt="mlte_logo" width="150"/>
 
-`mlte` (pronounced "melt") is a toolkit for machine learning testing and evaluation.
+`mlte` (pronounced "melt") is a framework and infrastructure for machine learning evaluation.
 
 [![Tests](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml/badge.svg)](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -16,3 +16,16 @@ $ pip install mlte-python
 ```
 
 Read the [documentation](https://mlte.readthedocs.io/en/latest/) for more details on getting started with `mlte`.
+
+### Citing This Work
+If you're interested in learning more about this work, you can read our [paper](https://arxiv.org/abs/2303.01998). While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use MLTE for academic research.
+
+```
+@article{maffey2023mlteing,
+  title={MLTEing Models: Negotiating, Evaluating, and Documenting Model and System Qualities},
+  author={Maffey, Katherine R and Dotterrer, Kyle and Niemann, Jennifer and Cruickshank, Iain
+  and Lewis, Grace A and K{\"a}stner, Christian},
+  journal={arXiv preprint arXiv:2303.01998},
+  year={2023}
+}
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ pip install mlte-python
 Read the [documentation](https://mlte.readthedocs.io/en/latest/) for more details on getting started with `mlte`.
 
 ### Citing This Work
+
 If you're interested in learning more about this work, you can read our [paper](https://arxiv.org/abs/2303.01998). While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use MLTE for academic research.
 
 ```


### PR DESCRIPTION
Resolves issue #174

@turingcompl33t, a note - it appears that the conference version of our paper is not posted publicly anywhere online, so I cited the arXiv version. We may want to change that at some point.

Please check the language I used to describe MLTE, because I updated it from 'toolkit'. 

Also, hilarious that you used cleverHans as an example because before I put that comment into the doc, I checked their repository to see if I had remembered correctly that they cited their paper. It's a great example.