### PR TITLE
Support Implicit Creation of Organizational Elements on Artifact Write

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check: check-format check-lint check-typecheck
 # NOTE: Only runs 3.10 environment (for speed)
 .PHONY: test
 test:
-	tox --develop -e py310 -- test/store/test_underlying.py
+	tox --develop -e py310 -- test
 
 # -----------------------------------------------------------------------------
 # Schema Generation / Vetting

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check: check-format check-lint check-typecheck
 # NOTE: Only runs 3.10 environment (for speed)
 .PHONY: test
 test:
-	tox --develop -e py310 -- test
+	tox --develop -e py310 -- test/store/test_underlying.py
 
 # -----------------------------------------------------------------------------
 # Schema Generation / Vetting

--- a/src/mlte/artifact/artifact.py
+++ b/src/mlte/artifact/artifact.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from mlte.artifact.model import ArtifactModel, ArtifactType
 from mlte.context import Context
 from mlte.session import session
-from mlte.store import Store
+from mlte.store.base import Store
 
 
 class Artifact:

--- a/src/mlte/artifact/artifact.py
+++ b/src/mlte/artifact/artifact.py
@@ -47,20 +47,27 @@ class Artifact:
             "Artifact.from_model() not implemented for abstract Artifact."
         )
 
-    def save(self) -> None:
+    def save(self, *, parents: bool = False) -> None:
         """
         Save an artifact with parameters from the configured global session.
 
         This is equivalent to calling:
             artifact.save_with(session().context, session().store)
+
+        :param parents: Indicates whether organizational elements for the
+        artifact are created implicitly on write (default: False)
         """
         self.save_with(session().context, session().store)
 
-    def save_with(self, context: Context, store: Store) -> None:
+    def save_with(
+        self, context: Context, store: Store, *, parents: bool = False
+    ) -> None:
         """
         Save an artifact with the given context and store configuration.
         :param context: The context in which to save the artifact
         :param store: The store in which to save the artifact
+        :param parents: Indicates whether organizational elements for the
+        artifact are created implicitly on write (default: False)
         """
         raise NotImplementedError(
             "Artifact.save_with() not implemented for abstract Artifact."

--- a/src/mlte/negotiation/negotiation_card.py
+++ b/src/mlte/negotiation/negotiation_card.py
@@ -12,7 +12,7 @@ import mlte.negotiation.model as model
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel, ArtifactType
 from mlte.context.context import Context
-from mlte.store.store import ManagedSession, Store
+from mlte.store.base import ManagedSession, Store
 
 
 class NegotiationCard(Artifact):

--- a/src/mlte/negotiation/negotiation_card.py
+++ b/src/mlte/negotiation/negotiation_card.py
@@ -58,11 +58,15 @@ class NegotiationCard(Artifact):
             model=model.body.model,
         )
 
-    def save_with(self, context: Context, store: Store) -> None:
+    def save_with(
+        self, context: Context, store: Store, *, parents: bool = False
+    ) -> None:
         """
         Save an artifact with the given context and store configuration.
         :param context: The context in which to save the artifact
         :param store: The store in which to save the artifact
+        :param parents: Indicates whether organizational elements for the
+        artifact are created implicitly on write (default: False)
         """
         with ManagedSession(store.session()) as handle:
             handle.write_artifact(
@@ -70,6 +74,7 @@ class NegotiationCard(Artifact):
                 context.model,
                 context.version,
                 self.to_model(),
+                parents=parents,
             )
 
     @staticmethod

--- a/src/mlte/session/state.py
+++ b/src/mlte/session/state.py
@@ -7,7 +7,7 @@ Session state management for the MLTE library.
 from typing import Optional
 
 from mlte.context import Context
-from mlte.store import Store
+from mlte.store.base import Store
 from mlte.store.factory import create_store
 
 

--- a/src/mlte/store/__init__.py
+++ b/src/mlte/store/__init__.py
@@ -1,3 +1,0 @@
-from .store import Store, StoreType, StoreURI, ManagedSession
-
-__all__ = ["Store", "StoreType", "StoreURI", "ManagedSession"]

--- a/src/mlte/store/base.py
+++ b/src/mlte/store/base.py
@@ -1,5 +1,5 @@
 """
-mlte/store/backend/store.py
+mlte/store/backend/base.py
 
 MLTE artifact store interface implementation.
 """

--- a/src/mlte/store/base.py
+++ b/src/mlte/store/base.py
@@ -240,6 +240,8 @@ class StoreSession:
         model_id: str,
         version_id: str,
         artifact: ArtifactModel,
+        *,
+        parents: bool = False,
     ) -> ArtifactModel:
         """
         Write an artifact.
@@ -247,6 +249,8 @@ class StoreSession:
         :param model_id: The identifier for the model
         :param version_id: The identifier for the model version
         :param artifact: The artifact
+        :param parents: Indicates whether organizational elements
+        for artifact should be implictly created (default: False)
         """
         raise NotImplementedError(
             "Cannot invoke method on abstract StoreSession."

--- a/src/mlte/store/factory.py
+++ b/src/mlte/store/factory.py
@@ -7,7 +7,7 @@ Top-level functions for artifact store creation.
 from mlte.store.underlying.memory import InMemoryStore
 from mlte.store.underlying.http import RemoteHttpStore
 from mlte.store.underlying.fs import LocalFileSystemStore
-from mlte.store.store import Store, StoreURI, StoreType
+from mlte.store.base import Store, StoreURI, StoreType
 
 
 def create_store(uri: str) -> Store:

--- a/src/mlte/store/underlying/fs.py
+++ b/src/mlte/store/underlying/fs.py
@@ -4,7 +4,6 @@ mlte/store/underlying/fs.py
 Implementation of local file system artifact store.
 """
 
-
 from typing import Any
 from pathlib import Path
 import json
@@ -21,6 +20,7 @@ from mlte.context.model import (
 )
 from mlte.artifact.model import ArtifactModel
 from mlte.store.query import Query
+import mlte.store.util as storeutil
 
 import mlte.store.error as errors
 
@@ -292,7 +292,12 @@ class LocalFileSystemStoreSession(StoreSession):
         model_id: str,
         version_id: str,
         artifact: ArtifactModel,
+        *,
+        parents: bool = False,
     ) -> ArtifactModel:
+        if parents:
+            storeutil.create_parents(self, namespace_id, model_id, version_id)
+
         artifacts = self._get_version_artifacts(
             namespace_id, model_id, version_id
         )

--- a/src/mlte/store/underlying/fs.py
+++ b/src/mlte/store/underlying/fs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import json
 import shutil
 
-from mlte.store.store import Store, StoreSession, StoreURI
+from mlte.store.base import Store, StoreSession, StoreURI
 from mlte.context.model import (
     Namespace,
     Model,

--- a/src/mlte/store/underlying/http.py
+++ b/src/mlte/store/underlying/http.py
@@ -10,7 +10,7 @@ import typing
 from typing import Any
 import requests
 import mlte.web.store.api.codes as codes
-from mlte.store.store import Store, StoreSession, StoreURI
+from mlte.store.base import Store, StoreSession, StoreURI
 from mlte.context.model import (
     Namespace,
     Model,

--- a/src/mlte/store/underlying/memory.py
+++ b/src/mlte/store/underlying/memory.py
@@ -17,6 +17,7 @@ from mlte.context.model import (
 )
 from mlte.artifact.model import ArtifactModel
 from mlte.store.query import Query
+import mlte.store.util as storeutil
 
 import mlte.store.error as errors
 
@@ -286,7 +287,12 @@ class InMemoryStoreSession(StoreSession):
         model_id: str,
         version_id: str,
         artifact: ArtifactModel,
+        *,
+        parents: bool = False,
     ) -> ArtifactModel:
+        if parents:
+            storeutil.create_parents(self, namespace_id, model_id, version_id)
+
         version = self._get_version_with_artifacts(
             namespace_id, model_id, version_id
         )

--- a/src/mlte/store/underlying/memory.py
+++ b/src/mlte/store/underlying/memory.py
@@ -6,7 +6,7 @@ Implementation of in-memory artifact store.
 
 from collections import OrderedDict
 
-from mlte.store.store import Store, StoreSession, StoreURI
+from mlte.store.base import Store, StoreSession, StoreURI
 from mlte.context.model import (
     Namespace,
     Model,

--- a/src/mlte/store/util.py
+++ b/src/mlte/store/util.py
@@ -1,0 +1,37 @@
+"""
+mlte/store/util.py
+
+Common utilities for store implementations.
+"""
+
+import mlte.store.error as errors
+from mlte.store.base import StoreSession
+from mlte.context.model import NamespaceCreate, ModelCreate, VersionCreate
+
+
+def create_parents(
+    session: StoreSession, namespace_id: str, model_id: str, version_id: str
+) -> None:
+    """
+    Create organizational elements within a store. If they exist, this operation is a noop.
+    :param store: The store instance in which elements are created
+    :param namespace_id: The namespace identifier
+    :param model_id: The model identifier
+    :param version_id: The version identifier
+    """
+    try:
+        session.create_namespace(NamespaceCreate(identifier=namespace_id))
+    except errors.ErrorAlreadyExists:
+        pass
+
+    try:
+        session.create_model(namespace_id, ModelCreate(identifier=model_id))
+    except errors.ErrorAlreadyExists:
+        pass
+
+    try:
+        session.create_version(
+            namespace_id, model_id, VersionCreate(identifier=version_id)
+        )
+    except errors.ErrorAlreadyExists:
+        pass

--- a/src/mlte/web/store/api/dependencies.py
+++ b/src/mlte/web/store/api/dependencies.py
@@ -15,7 +15,7 @@ solution that involves manual context management with a global state object.
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from mlte.store.store import StoreSession
+from mlte.store.base import StoreSession
 from mlte.web.store.state import state
 
 

--- a/src/mlte/web/store/api/endpoints/artifact.py
+++ b/src/mlte/web/store/api/endpoints/artifact.py
@@ -11,6 +11,7 @@ import mlte.web.store.api.codes as codes
 from mlte.artifact.model import ArtifactModel
 from mlte.store.query import Query
 from mlte.web.store.api import dependencies
+from mlte.web.store.api.model import WriteArtifactRequest, WriteArtifactResponse
 
 # The router exported by this submodule
 router = APIRouter()
@@ -21,21 +22,26 @@ def write_artifact(
     namespace_id: str,
     model_id: str,
     version_id: str,
-    artifact: ArtifactModel,
-) -> ArtifactModel:
+    request: WriteArtifactRequest,
+) -> WriteArtifactResponse:
     """
     Write an artifact.
     :param namespace_id: The namespace identifier
     :param model_id: The model identifier
     :param version_id: The version identifier
-    :param model: The artifact model
+    :param request: The artifact write request
     :return: The created artifact
     """
     with dependencies.session() as handle:
         try:
-            return handle.write_artifact(
-                namespace_id, model_id, version_id, artifact
+            artifact = handle.write_artifact(
+                namespace_id,
+                model_id,
+                version_id,
+                request.artifact,
+                parents=request.parents,
             )
+            return WriteArtifactResponse(artifact=artifact)
         except errors.ErrorNotFound as e:
             raise HTTPException(
                 status_code=codes.NOT_FOUND, detail=f"{e} not found."

--- a/src/mlte/web/store/api/model.py
+++ b/src/mlte/web/store/api/model.py
@@ -1,0 +1,30 @@
+"""
+mlte/web/store/api/model.py
+
+Model implementations for artifact store.
+
+NOTE(Kyle): I am unsure as to how I want to refactor the API to account
+for additional meta-models like these. This worked well for write request;
+should the other endpoints be refactored to look more like this one?
+"""
+
+from pydantic import BaseModel
+
+from mlte.artifact.model import ArtifactModel
+
+
+class WriteArtifactRequest(BaseModel):
+    """Defines the data in a POST request to write an artifact."""
+
+    artifact: ArtifactModel
+    """The model for the artifact to write."""
+
+    parents: bool
+    """Indicates whether organizational elements should be created."""
+
+
+class WriteArtifactResponse(BaseModel):
+    """Defines the data in a response to writing an artifact."""
+
+    artifact: ArtifactModel
+    """The model for the artifact that was written."""

--- a/src/mlte/web/store/main.py
+++ b/src/mlte/web/store/main.py
@@ -10,8 +10,8 @@ import sys
 import uvicorn
 
 import mlte.web.store.app_factory as app_factory
+from mlte.store.base import StoreType
 from mlte.store.factory import create_store
-from mlte.store.store import StoreType
 from mlte.web.store.api.api import api_router
 from mlte.web.store.core.config import settings
 from mlte.web.store.state import state

--- a/src/mlte/web/store/state/state.py
+++ b/src/mlte/web/store/state/state.py
@@ -6,7 +6,7 @@ Globally-accessible application state.
 
 from typing import Optional
 
-from mlte.store.store import Store
+from mlte.store.base import Store
 
 
 class State:

--- a/test/negotiation/test_negotiation_card.py
+++ b/test/negotiation/test_negotiation_card.py
@@ -6,6 +6,7 @@ Unit tests for negotiation card.
 
 import pytest
 
+import mlte.store.error as errors
 from mlte.context.context import Context
 from mlte.context.model import ModelCreate, NamespaceCreate, VersionCreate
 from mlte.negotiation.negotiation_card import NegotiationCard
@@ -20,6 +21,13 @@ MODEL_ID = "model0"
 
 # The version identifier for default context
 VERSION_ID = "v0"
+
+
+@pytest.fixture(scope="function")
+def store() -> Store:
+    """Create an in-memory artifact store."""
+    store = create_store("memory://")
+    return store
 
 
 @pytest.fixture(scope="function")
@@ -54,3 +62,20 @@ def test_save_load(store_with_context: tuple[Store, Context]) -> None:
 
     loaded = NegotiationCard.load_with("my-card", ctx, store)
     assert loaded == card
+
+
+def test_save_noparents(store: Store) -> None:
+    """Save fails when no parents are present."""
+    ctx = Context(NAMESPACE_ID, MODEL_ID, VERSION_ID)
+
+    card = NegotiationCard("my-card")
+    with pytest.raises(errors.ErrorNotFound):
+        card.save_with(ctx, store)
+
+
+def test_save_parents(store: Store) -> None:
+    """Save succeeds when parents are present."""
+    ctx = Context(NAMESPACE_ID, MODEL_ID, VERSION_ID)
+
+    card = NegotiationCard("my-card")
+    card.save_with(ctx, store, parents=True)

--- a/test/negotiation/test_negotiation_card.py
+++ b/test/negotiation/test_negotiation_card.py
@@ -9,8 +9,8 @@ import pytest
 from mlte.context.context import Context
 from mlte.context.model import ModelCreate, NamespaceCreate, VersionCreate
 from mlte.negotiation.negotiation_card import NegotiationCard
+from mlte.store.base import ManagedSession, Store
 from mlte.store.factory import create_store
-from mlte.store.store import ManagedSession, Store
 
 # The namespace identifier for default context
 NAMESPACE_ID = "ns0"

--- a/test/store/fixture.py
+++ b/test/store/fixture.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 
 import mlte.web.store.app_factory as app_factory
 from mlte.artifact.model import ArtifactType
-from mlte.store import StoreURI
+from mlte.store.base import StoreURI
 from mlte.store.factory import create_store
 from mlte.store.underlying.fs import LocalFileSystemStore
 from mlte.store.underlying.http import (

--- a/test/store/test_underlying.py
+++ b/test/store/test_underlying.py
@@ -209,3 +209,61 @@ def test_artifact(
             _ = handle.read_artifact(
                 namespace_id, model_id, version_id, artifact_id
             )
+
+
+@pytest.mark.parametrize("store_fixture_name,artifact_type", stores_and_types())
+def test_artifact_without_parents(
+    store_fixture_name: str,
+    artifact_type: ArtifactType,
+    request: pytest.FixtureRequest,
+) -> None:
+    """An artifact does not create organizational elements by default, on write."""
+    store: Store = request.getfixturevalue(store_fixture_name)
+
+    namespace_id = "namespace"
+    model_id = "model"
+    version_id = "version"
+    artifact_id = "myid"
+
+    artifact = ArtifactFactory.make(artifact_type, artifact_id)
+
+    # The write fails
+    with pytest.raises(errors.ErrorNotFound):
+        with ManagedSession(store.session()) as handle:
+            _ = handle.write_artifact(
+                namespace_id, model_id, version_id, artifact
+            )
+
+
+@pytest.mark.parametrize("store_fixture_name,artifact_type", stores_and_types())
+def test_artifact_parents(
+    store_fixture_name: str,
+    artifact_type: ArtifactType,
+    request: pytest.FixtureRequest,
+) -> None:
+    """An artifact store can create organizational elements implicitly, on write."""
+    store: Store = request.getfixturevalue(store_fixture_name)
+
+    namespace_id = "namespace"
+    model_id = "model"
+    version_id = "version"
+    artifact_id = "myid"
+
+    artifact = ArtifactFactory.make(artifact_type, artifact_id)
+
+    # The write succeeds
+    with ManagedSession(store.session()) as handle:
+        _ = handle.write_artifact(
+            namespace_id, model_id, version_id, artifact, parents=True
+        )
+
+    # The organizational elements are present
+    with ManagedSession(store.session()) as handle:
+        assert len(handle.list_namespaces()) == 1
+        assert len(handle.list_models(namespace_id)) == 1
+        assert len(handle.list_versions(namespace_id, model_id)) == 1
+
+    # The artifact is present
+    with ManagedSession(store.session()) as handle:
+        read = handle.read_artifacts(namespace_id, model_id, version_id)
+        assert len(read) == 1

--- a/test/store/test_underlying.py
+++ b/test/store/test_underlying.py
@@ -9,7 +9,7 @@ import pytest
 import mlte.store.error as errors
 from mlte.artifact.model import ArtifactType
 from mlte.context.model import ModelCreate, NamespaceCreate, VersionCreate
-from mlte.store import ManagedSession, Store, StoreURI
+from mlte.store.base import ManagedSession, Store, StoreURI
 from mlte.store.underlying.fs import LocalFileSystemStore
 from mlte.store.underlying.http import RemoteHttpStore
 from mlte.store.underlying.memory import InMemoryStore

--- a/test/web/store/test_artifact.py
+++ b/test/web/store/test_artifact.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from mlte.artifact.model import ArtifactModel, ArtifactType
 from mlte.context.model import ModelCreate, NamespaceCreate, VersionCreate
 from mlte.store.query import Query
+from mlte.web.store.api.model import WriteArtifactRequest
 
 from ...fixture.artifact import ArtifactFactory
 from .fixure.http import clients_and_types, mem_client  # noqa
@@ -40,9 +41,10 @@ def test_write(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type)
+    r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=a.dict(),
+        json=r.dict(),
     )
     assert res.status_code == 200
 
@@ -60,13 +62,14 @@ def test_read(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type, id="id0")
+    r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=a.dict(),
+        json=r.dict(),
     )
     assert res.status_code == 200
-
-    created = ArtifactModel(**res.json())
+    artifact = res.json()["artifact"]
+    created = ArtifactModel(**artifact)
 
     res = client.get(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact/id0"
@@ -89,12 +92,14 @@ def test_search(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type)
+    r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=a.dict(),
+        json=r.dict(),
     )
     assert res.status_code == 200
-    created = ArtifactModel(**res.json())
+    artifact = res.json()["artifact"]
+    created = ArtifactModel(**artifact)
 
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact/search",
@@ -122,9 +127,10 @@ def test_delete(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type, "id0")
+    r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=a.dict(),
+        json=r.dict(),
     )
     assert res.status_code == 200
 


### PR DESCRIPTION
Resolves #195.

This PR adds the ability to implicitly create organizational elements on write to the artifact store. Three distinct interfaces have been updated:

- The `Store` interface now supports an optional parameter, `parents`, to `write_artifact`, that specifies that organizational elements should be created if they do not exist
- The web API endpoint for artifact write operations has been modified to support specifying `parents` in the request
- The artifact protocol base type, `Artifact`, now supports `parents` in `Artifact.save()` and `Artifact.save_with()`

Ultimately, this means that we can now write code like the following:

```python
card = NegotiationCard("my-card")
card.save(parents=True)
```

And the write will succeed, even when the namespace, model, and version were not previously created for the artifact.