### PR TITLE
Unify the Implementation of Metaclass Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,7 @@ check: check-format check-lint check-typecheck
 # Unit Tests
 # -----------------------------------------------------------------------------
 
-# Run unit tests with tox
-# NOTE: Only runs 3.10 environment (for speed)
+# Run unit tests with pytest
 .PHONY: test
 test:
 	poetry run pytest test

--- a/mlte/_private/meta.py
+++ b/mlte/_private/meta.py
@@ -1,0 +1,15 @@
+"""
+mlte/private/meta.py
+
+Metaclasses helpers.
+"""
+
+
+def has_callable(type, name) -> bool:
+    """Determine if `type` has a callable attribute with the given name."""
+    return hasattr(type, name) and callable(getattr(type, name))
+
+
+def has_callables(type, *names: str) -> bool:
+    """ "Determine if `type` has callables with the given names."""
+    return all(has_callable(type, name) for name in names)

--- a/mlte/artifact/artifact.py
+++ b/mlte/artifact/artifact.py
@@ -6,6 +6,9 @@ Artifact protocol implementation.
 
 from __future__ import annotations
 
+import abc
+
+import mlte._private.meta as meta
 from mlte.artifact.model import ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.context.context import Context
@@ -13,7 +16,7 @@ from mlte.session.state import session
 from mlte.store.base import ManagedSession, Store
 
 
-class Artifact:
+class Artifact(metaclass=abc.ABCMeta):
     """
     The MLTE artifact protocol implementation.
 
@@ -23,6 +26,10 @@ class Artifact:
     by a common protocol that allows us to perform common
     operations with them, namely persistence.
     """
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        return meta.has_callables(subclass, "to_model", "from_model")
 
     def __init__(self, identifier: str, type: ArtifactType) -> None:
         self.identifier = identifier
@@ -35,6 +42,7 @@ class Artifact:
         self.type = type
         """The identifier for the artifact type"""
 
+    @abc.abstractmethod
     def to_model(self) -> ArtifactModel:
         """Serialize an artifact to its corresponding model."""
         raise NotImplementedError(
@@ -42,6 +50,7 @@ class Artifact:
         )
 
     @classmethod
+    @abc.abstractmethod
     def from_model(cls, _: ArtifactModel) -> Artifact:
         """Deserialize an artifact from its corresponding model."""
         raise NotImplementedError(

--- a/mlte/measurement/measurement.py
+++ b/mlte/measurement/measurement.py
@@ -10,14 +10,10 @@ import abc
 import typing
 from typing import Type, Optional
 
+import mlte._private.meta as meta
 from mlte.value.artifact import Value
 from mlte.value.types.opaque import Opaque
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
-
-
-def _has_callable(type, name) -> bool:
-    """Determine if `type` has a callable attribute with the given name."""
-    return hasattr(type, name) and callable(getattr(type, name))
 
 
 class Measurement(metaclass=abc.ABCMeta):
@@ -28,7 +24,7 @@ class Measurement(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, subclass):
         """Define the interface for all concrete measurements."""
-        return all(_has_callable(subclass, method) for method in ["__call__"])
+        return meta.has_callables(subclass, "__call__")
 
     def __init__(
         self, instance: Measurement, identifier: str, info: Optional[str] = None

--- a/mlte/property/property.py
+++ b/mlte/property/property.py
@@ -10,11 +10,7 @@ import abc
 import importlib
 import pkgutil
 from typing import Type, Dict
-
-
-def _has_callable(type, name) -> bool:
-    """Determine if `type` has a callable attribute with the given name."""
-    return hasattr(type, name) and callable(getattr(type, name))
+import mlte._private.meta as meta
 
 
 class Property(metaclass=abc.ABCMeta):
@@ -23,10 +19,7 @@ class Property(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, subclass):
         """Define the interface for all concrete properties."""
-        return all(
-            _has_callable(subclass, method)
-            for method in ["__init__", "__repr__"]
-        )
+        return meta.has_callables(subclass, "__init__", "__repr__")
 
     def __init__(self, name: str, description: str, rationale: str):
         """

--- a/mlte/validation/result.py
+++ b/mlte/validation/result.py
@@ -11,12 +11,7 @@ from typing import Optional, Any, Dict
 import sys
 
 from mlte.evidence.metadata import EvidenceMetadata
-
-
-def _has_callable(type, name) -> bool:
-    """Determine if `type` has a callable attribute with the given name."""
-    return hasattr(type, name) and callable(getattr(type, name))
-
+import mlte._private.meta as meta
 
 # -----------------------------------------------------------------------------
 # Validation Results
@@ -29,10 +24,7 @@ class Result(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, subclass):
         """Define the interface for all concrete Result."""
-        return all(
-            _has_callable(subclass, method)
-            for method in ["__bool__", "__str__"]
-        )
+        return meta.has_callables(subclass, "__bool__", "__str__")
 
     def __init__(self, message: str):
         """

--- a/mlte/value/artifact.py
+++ b/mlte/value/artifact.py
@@ -14,11 +14,6 @@ from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
 
 
-def _has_callable(type, name) -> bool:
-    """Determine if `type` has a callable attribute with the given name."""
-    return hasattr(type, name) and callable(getattr(type, name))
-
-
 class Value(Artifact, metaclass=abc.ABCMeta):
     """
     The Value class serves as the base class of all
@@ -28,14 +23,6 @@ class Value(Artifact, metaclass=abc.ABCMeta):
     encapsulates the functionality required to uniquely
     associate evaluation results with the originating measurement.
     """
-
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        """Define the interface for all Value subclasses."""
-        return all(
-            _has_callable(subclass, method)
-            for method in ["to_model", "from_model"]
-        )
 
     def __init__(self, instance: Value, metadata: EvidenceMetadata):
         """

--- a/mlte/value/base.py
+++ b/mlte/value/base.py
@@ -17,16 +17,12 @@ from __future__ import annotations
 import abc
 from typing import Any, Dict
 
+import mlte._private.meta as meta
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.value.model import OpaqueValueModel, ValueModel, ValueType
-
-
-def _has_callable(type, name) -> bool:
-    """Determine if `type` has a callable attribute with the given name."""
-    return hasattr(type, name) and callable(getattr(type, name))
 
 
 class Value(Artifact, metaclass=abc.ABCMeta):
@@ -35,10 +31,7 @@ class Value(Artifact, metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, subclass):
         """Define the interface for all Value subclasses."""
-        return all(
-            _has_callable(subclass, method)
-            for method in ["serialize", "deserialize"]
-        )
+        return meta.has_callables(subclass, "serialize", "deserialize")
 
     def __init__(self, instance: Value, metadata: EvidenceMetadata) -> None:
         """
@@ -55,6 +48,7 @@ class Value(Artifact, metaclass=abc.ABCMeta):
         self.typename: str = type(instance).__name__
         """The type of the value itself."""
 
+    @abc.abstractmethod
     def serialize(self) -> Dict[str, Any]:
         """
         Serialize the value to a JSON-compatible dictionary.
@@ -63,6 +57,7 @@ class Value(Artifact, metaclass=abc.ABCMeta):
         raise NotImplementedError("Value.serialize()")
 
     @classmethod
+    @abc.abstractmethod
     def deserialize(
         cls, metadata: EvidenceMetadata, data: Dict[str, Any]
     ) -> Value:

--- a/test/value/test_extension.py
+++ b/test/value/test_extension.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
+import pytest
+
 from mlte.context.context import Context
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.store.base import Store
@@ -38,6 +40,15 @@ class ConfusionMatrix(Value):
         if not isinstance(other, ConfusionMatrix):
             return False
         return self.matrix == other.matrix
+
+
+class BadInteger(Value):
+    """An extension value that does not implement the interface."""
+
+    def __init__(self, metadata: EvidenceMetadata, integer: int):
+        super().__init__(self, metadata)
+
+        self.integer = integer
 
 
 def test_serde() -> None:
@@ -79,3 +90,12 @@ def test_save_load(store_with_context: Tuple[Store, Context]) -> None:  # noqa
 
     loaded = ConfusionMatrix.load_with("id.value", ctx, store)
     assert loaded == cm
+
+
+def test_subclass_fail() -> None:
+    """A value type that fails to meet the interface cannot be instantiated."""
+    em = EvidenceMetadata(
+        measurement_type="typename", identifier=Identifier(name="id")
+    )
+    with pytest.raises(TypeError):
+        _ = BadInteger(em, 1)  # type: ignore


### PR DESCRIPTION
Resolves #202.

In addition, it adds a unit test for `mlte.value.base.Value` to ensure that custom implementations that do not meet the interface cannot be instantiated.