### PR TITLE
Refactor `mlte.value.base.Value` and Fix Demonstration

### DIFF
--- a/demo/confusion_matrix.py
+++ b/demo/confusion_matrix.py
@@ -37,7 +37,7 @@ class ConfusionMatrix(ValueBase):
         if not isinstance(other, ConfusionMatrix):
             return False
         return self.matrix == other.matrix
-    
+
     def __str__(self) -> str:
         return f"{self.matrix}"
 
@@ -66,5 +66,3 @@ class ConfusionMatrix(ValueBase):
             ),
         )
         return condition
-
-

--- a/demo/confusion_matrix.py
+++ b/demo/confusion_matrix.py
@@ -6,33 +6,51 @@ Implementation of ConfusionMatrix value.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.validation import Condition, Failure, Result, Success
-from mlte.value import Value
+from mlte.value.base import ValueBase
 
 
-class ConfusionMatrix(Value):
-    def __init__(self, evidence_metadata: EvidenceMetadata, matrix: np.ndarray):
-        super().__init__(self, evidence_metadata)
+class ConfusionMatrix(ValueBase):
+    """A sample extension value type."""
 
-        self.matrix: np.ndarray = matrix
-        """Underlying matrix represented as numpy array."""
+    def __init__(self, metadata: EvidenceMetadata, matrix: np.ndarray):
+        super().__init__(self, metadata)
+
+        self.matrix = matrix
+        """Underlying matrix represented as two-dimensional array."""
 
     def serialize(self) -> Dict[str, Any]:
-        return {"matrix": [[int(val) for val in row] for row in self.matrix]}
+        return {"matrix": self.matrix}
 
     @staticmethod
     def deserialize(
-        evidence_metadata: EvidenceMetadata, json_: Dict[str, Any]
+        metadata: EvidenceMetadata, data: Dict[str, Any]
     ) -> ConfusionMatrix:
-        return ConfusionMatrix(evidence_metadata, np.asarray(json_["matrix"]))
+        return ConfusionMatrix(metadata, data["matrix"])
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ConfusionMatrix):
+            return False
+        return self.matrix == other.matrix
+    
     def __str__(self) -> str:
-        return str(self.matrix)
+        return f"{self.matrix}"
+
+    @property
+    def misclassifications(self) -> int:
+        count = 0
+        for i in range(len(self.matrix)):
+            row = self.matrix[i]
+            for j in range(len(row)):
+                if i == j:
+                    continue
+                count += row[j]
+        return count
 
     @classmethod
     def misclassification_count_less_than(cls, threshold: int) -> Condition:
@@ -49,13 +67,4 @@ class ConfusionMatrix(Value):
         )
         return condition
 
-    @property
-    def misclassifications(self) -> int:
-        count = 0
-        for i in range(len(self.matrix)):
-            row = self.matrix[i]
-            for j in range(len(row)):
-                if i == j:
-                    continue
-                count += row[j]
-        return count
+

--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -26,24 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Preliminaries for loading the package locally\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "def package_root() -> str:\n",
-    "    \"\"\"Resolve the path to the project root.\"\"\"\n",
-    "    return os.path.abspath(os.path.join(os.getcwd(), \"..\", \"src/\"))\n",
-    "\n",
-    "sys.path.append(package_root())\n",
-    "sys.path.append(os.getcwd())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import os\n",
     "from pathlib import Path\n",
     "\n",
@@ -136,7 +118,6 @@
     "store_path = os.path.join(os.getcwd(), \"store\")\n",
     "os.makedirs(store_path, exist_ok=True)   # Ensure we are creating the folder if it is not there.\n",
     "\n",
-    "#f\"local://{store_path}\"\n",
     "set_context(\"ns\", \"IrisClassifier\", \"0.0.1\")\n",
     "set_store(\"memory://\")"
    ]
@@ -345,7 +326,7 @@
     "print(accuracy)\n",
     "\n",
     "# Save to artifact store\n",
-    "accuracy.save()"
+    "accuracy.save(parents=True)"
    ]
   },
   {
@@ -374,7 +355,7 @@
     "print(matrix)\n",
     "\n",
     "# Save to artifact store\n",
-    "matrix.save()"
+    "matrix.save(parents=True)"
    ]
   },
   {

--- a/demo/report.ipynb
+++ b/demo/report.ipynb
@@ -24,24 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Preliminaries for loading the package locally\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "def package_root() -> str:\n",
-    "    \"\"\"Resolve the path to the project root.\"\"\"\n",
-    "    return os.path.abspath(os.path.join(os.getcwd(), \"..\", \"src/\"))\n",
-    "\n",
-    "sys.path.append(package_root())\n",
-    "sys.path.append(os.getcwd())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import os\n",
     "from pathlib import Path\n",
     "\n",

--- a/demo/requirements.ipynb
+++ b/demo/requirements.ipynb
@@ -15,31 +15,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preliminaries"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Preliminaries for loading the package locally\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "def package_root() -> str:\n",
-    "    \"\"\"Resolve the path to the project root.\"\"\"\n",
-    "    return os.path.abspath(os.path.join(os.getcwd(), \"..\", \"src/\"))\n",
-    "\n",
-    "sys.path.append(package_root())"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "#### Initialize MLTE Context\n",
     "\n",
     "MLTE contains a global context that manages the currently active _session_. Initializing the context tells MLTE how to store all of the artifacts that it produces."
@@ -127,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/mlte/measurement/external_measurement.py
+++ b/mlte/measurement/external_measurement.py
@@ -33,7 +33,7 @@ class ExternalMeasurement(Measurement):
         """
         super().__init__(self, identifier)
 
-        if not issubclass(Value, value_type):
+        if not issubclass(value_type, Value):
             raise Exception(
                 f"Value type provided is not a subtype of Value: {value_type}"
             )

--- a/mlte/value/base.py
+++ b/mlte/value/base.py
@@ -18,14 +18,14 @@ import abc
 from typing import Any, Dict
 
 import mlte._private.meta as meta
-from mlte.artifact.artifact import Artifact
+import mlte.value.artifact as artifact
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.value.model import OpaqueValueModel, ValueModel, ValueType
 
 
-class Value(Artifact, metaclass=abc.ABCMeta):
+class ValueBase(artifact.Value, metaclass=abc.ABCMeta):
     """The base class for MLTE value extensions."""
 
     @classmethod
@@ -33,20 +33,13 @@ class Value(Artifact, metaclass=abc.ABCMeta):
         """Define the interface for all Value subclasses."""
         return meta.has_callables(subclass, "serialize", "deserialize")
 
-    def __init__(self, instance: Value, metadata: EvidenceMetadata) -> None:
+    def __init__(self, instance: ValueBase, metadata: EvidenceMetadata) -> None:
         """
         Initialize a MLTE value.
         :param instance: The subclass instance
         :param metadata: Evidence metadata associated with the value
         """
-        identifier = f"{metadata.identifier}.value"
-        super().__init__(identifier, ArtifactType.VALUE)
-
-        self.metadata = metadata
-        """Evidence metadata associated with the value."""
-
-        self.typename: str = type(instance).__name__
-        """The type of the value itself."""
+        super().__init__(instance, metadata)
 
     @abc.abstractmethod
     def serialize(self) -> Dict[str, Any]:
@@ -54,20 +47,20 @@ class Value(Artifact, metaclass=abc.ABCMeta):
         Serialize the value to a JSON-compatible dictionary.
         :return: The dictionary representation
         """
-        raise NotImplementedError("Value.serialize()")
+        raise NotImplementedError("ValueBase.serialize()")
 
     @classmethod
     @abc.abstractmethod
     def deserialize(
         cls, metadata: EvidenceMetadata, data: Dict[str, Any]
-    ) -> Value:
+    ) -> ValueBase:
         """
         Deserialize a Value instance from serialized representation.
         :param metadata: Evidence metadata associated with the value
         :param data: The serialized representation
         :return: The deserialized value
         """
-        raise NotImplementedError("Value.deserialize()")
+        raise NotImplementedError("ValueBase.deserialize()")
 
     def to_model(self) -> ArtifactModel:
         """
@@ -88,7 +81,7 @@ class Value(Artifact, metaclass=abc.ABCMeta):
         )
 
     @classmethod
-    def from_model(cls, model: ArtifactModel) -> Value:  # noqa[override]
+    def from_model(cls, model: ArtifactModel) -> ValueBase:  # noqa[override]
         """
         Deserialize a value from its corresponding model.
         :param model: The artifact model

--- a/test/measurement/test_external_measurement.py
+++ b/test/measurement/test_external_measurement.py
@@ -4,11 +4,38 @@ test/measurement/test_external_measurement.py
 Unit test for ExternalMeasurement.
 """
 
+from __future__ import annotations
+
+from typing import Any, Dict
+
 import pytest
 
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.measurement import ExternalMeasurement
+from mlte.value.base import ValueBase
 from mlte.value.types.integer import Integer
+
+
+class BigInteger(ValueBase):
+    """A sample extension value type."""
+
+    def __init__(self, metadata: EvidenceMetadata, integer: int):
+        super().__init__(self, metadata)
+        self.integer = integer
+
+    def serialize(self) -> Dict[str, Any]:
+        return {"integer": self.integer}
+
+    @staticmethod
+    def deserialize(
+        metadata: EvidenceMetadata, data: Dict[str, Any]
+    ) -> BigInteger:
+        return BigInteger(metadata, data["integer"])
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BigInteger):
+            return False
+        return self.integer == other.integer
 
 
 def _dummy_calculation(x: int, y: int):
@@ -26,7 +53,9 @@ def _dummy_calculation(x: int, y: int):
     return (x + y) * 2
 
 
-def test_evaluate_external():
+def test_evaluate_external() -> None:
+    """An external measurement can be evaluated to a MLTE builtin."""
+
     x = 1
     y = 2
     expected_value = _dummy_calculation(x, y)
@@ -44,7 +73,29 @@ def test_evaluate_external():
     assert result == expected_result
 
 
-def test_evaluate_ingest():
+def test_evaluate_external_base() -> None:
+    """An external measurement can be evaluated to a MLTE value extension."""
+
+    x = 1
+    y = 2
+    expected_value = _dummy_calculation(x, y)
+    expected_result = BigInteger(
+        EvidenceMetadata(
+            measurement_type="dummy", identifier=Identifier(name="test")
+        ),
+        expected_value,
+    )
+
+    measurement = ExternalMeasurement("dummy", BigInteger, _dummy_calculation)
+    result = measurement.evaluate(x, y)
+
+    assert isinstance(result, BigInteger)
+    assert result == expected_result
+
+
+def test_evaluate_ingest() -> None:
+    """An external measurement can be used to ingest a value directly."""
+
     expected_value = 1000
     expected_result = Integer(
         EvidenceMetadata(
@@ -60,17 +111,41 @@ def test_evaluate_ingest():
     assert result == expected_result
 
 
-def test_invalid_result_type():
+def test_evaluate_ingest_base() -> None:
+    """An external measurement can be used to ingest an extension value."""
+
+    expected_value = 1000
+    expected_result = BigInteger(
+        EvidenceMetadata(
+            measurement_type="dummy", identifier=Identifier(name="test")
+        ),
+        expected_value,
+    )
+
+    measurement = ExternalMeasurement("dummy", BigInteger)
+    result = measurement.ingest(expected_value)
+
+    assert isinstance(result, BigInteger)
+    assert result == expected_result
+
+
+def test_invalid_result_type() -> None:
+    """An external measurement cannot be instantiated with a bad result type."""
+
     with pytest.raises(Exception):
-        ExternalMeasurement("dummy", int)
+        _ = ExternalMeasurement("dummy", int)
 
 
-def test_invalid_function():
+def test_invalid_function() -> None:
+    """An external measurement cannot be instantiated with a bad function type."""
+
     with pytest.raises(Exception):
         ExternalMeasurement("dummy", Integer, "not_a_function")
 
 
-def test_evaluate_no_function():
+def test_evaluate_no_function() -> None:
+    """An external measurement cannot be evaluated with no function."""
+
     x = 1
     y = 2
 

--- a/test/value/test_extension.py
+++ b/test/value/test_extension.py
@@ -13,12 +13,12 @@ import pytest
 from mlte.context.context import Context
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.store.base import Store
-from mlte.value.base import Value
+from mlte.value.base import ValueBase
 
 from ..fixture.store import store_with_context  # noqa
 
 
-class ConfusionMatrix(Value):
+class ConfusionMatrix(ValueBase):
     """A sample extension value type."""
 
     def __init__(self, metadata: EvidenceMetadata, matrix: List[List[int]]):
@@ -42,7 +42,7 @@ class ConfusionMatrix(Value):
         return self.matrix == other.matrix
 
 
-class BadInteger(Value):
+class BadInteger(ValueBase):
     """An extension value that does not implement the interface."""
 
     def __init__(self, metadata: EvidenceMetadata, integer: int):


### PR DESCRIPTION
Resolves #203.

This PR refactors `mlte.value.base.Value` to `mlte.value.base.ValueBase`. The name is changed, and the type is made a subclass of `mlte.value.artifact.Value`. This simplifies the implementation of other features (like `ExternalMeasurement`). 

Note that this is what @sebastian-echeverria urged me to do in the first place. I failed to see the utility then, but in the process of fixing the demo functionality that I broke, it became clear.