### PR TITLE
Import Sorting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
       run: curl -sSL https://install.python-poetry.org | python -
     - name: Install dependencies
       run: poetry install
+    - name: Sort imports with isort
+      run: make check-isort
     - name: Format with black
       run: make check-format
     - name: Lint with flake8
@@ -50,6 +52,8 @@ jobs:
       run: curl -sSL https://install.python-poetry.org | python -
     - name: Install dependencies
       run: poetry install
+    - name: Sort imports with isort
+      run: make check-isort
     - name: Format with black
       run: make check-format
     - name: Lint with flake8
@@ -78,6 +82,8 @@ jobs:
       run: curl -sSL https://install.python-poetry.org | python -
     - name: Install dependencies
       run: poetry install
+    - name: Sort imports with isort
+      run: make check-isort
     - name: Format with black
       run: make check-format
     - name: Lint with flake8

--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,19 @@
 
 .PHONY: isort
 isort:	
-	poetry run isort mlte/artifact
-	poetry run isort mlte/negotiation
-	poetry run isort mlte/value
-	poetry run isort mlte/web/
-	
+	poetry run isort mlte/
 	poetry run isort test/
 	poetry run isort testbed/
 	poetry run isort demo/*.py
 	poetry run isort tools/
 
-# .PHONY: check-isort
-# check-isort:
-# 	isort --check src/
-# 	isort --check test/
-# 	isort --check testbed/
-# 	isort --check demo/*.py
+.PHONY: check-isort
+check-isort:
+	poetry run isort --check mlte/
+	poetry run isort --check test/
+	poetry run isort --check testbed/
+	poetry run isort --check demo/*.py
+	poetry run isort --check tools/
 
 # Format all source code
 .PHONY: format
@@ -73,7 +70,7 @@ qa: isort format lint typecheck
 
 # Check all QA tasks
 .PHONY: check
-check: check-format check-lint check-typecheck
+check: check-isort check-format check-lint check-typecheck
 
 # -----------------------------------------------------------------------------
 # Unit Tests

--- a/demo/confusion_matrix.py
+++ b/demo/confusion_matrix.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, List
 import numpy as np
 
 from mlte.evidence.metadata import EvidenceMetadata
-from mlte.validation import Condition, Failure, Result, Success
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
 from mlte.value.base import ValueBase
 
 

--- a/mlte/_private/job.py
+++ b/mlte/_private/job.py
@@ -4,11 +4,11 @@ mlte/_private/job.py
 Optional helpers that can be used to start external processes.
 """
 
+import subprocess
 import sys
 import threading
-import subprocess
-from typing import List
 from pathlib import Path
+from typing import List
 
 
 def _get_interpreter_path() -> Path:

--- a/mlte/_private/schema.py
+++ b/mlte/_private/schema.py
@@ -11,11 +11,12 @@ Acknowledgements:
     https://github.com/tensorflow/model-card-toolkit
 """
 
-import os
 import json
+import os
 import pkgutil
-import jsonschema
 from typing import Any, Dict, Optional
+
+import jsonschema
 
 # The identifier for the latest schema for Value
 VALUE_LATEST_SCHEMA_VERSION = "0.0.1"

--- a/mlte/api/__init__.py
+++ b/mlte/api/__init__.py
@@ -1,10 +1,10 @@
 from mlte.api.api import (
-    read_value,
-    write_value,
     read_spec,
+    read_validatedspec,
+    read_value,
     write_spec,
     write_validatedspec,
-    read_validatedspec,
+    write_value,
 )
 
 __all__ = [

--- a/mlte/api/api.py
+++ b/mlte/api/api.py
@@ -7,7 +7,7 @@ Generic API wrapper for MLTE artifact store.
 # TODO(Kyle): This entire sub-package is now deprecated in favor
 # of the new implementation of the artifact store interface.
 
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 # -----------------------------------------------------------------------------
 # Value

--- a/mlte/api/local/__init__.py
+++ b/mlte/api/local/__init__.py
@@ -1,10 +1,10 @@
 from .api import (
-    read_value,
-    write_value,
     read_spec,
-    write_spec,
     read_validatedspec,
+    read_value,
+    write_spec,
     write_validatedspec,
+    write_value,
 )
 
 __all__ = [

--- a/mlte/api/local/api.py
+++ b/mlte/api/local/api.py
@@ -4,7 +4,7 @@ mlte/api/local/api.py
 Value persistence API for local filesystem.
 """
 
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 # The prefix that indicates a local filesystem directory is used
 LOCAL_URI_PREFIX = "local://"

--- a/mlte/cli/cli.py
+++ b/mlte/cli/cli.py
@@ -4,11 +4,11 @@ mlte/cli/cli.py
 Top-level command line interface.
 """
 
-import sys
 import argparse
+import sys
 
-import mlte.web.store.main as server
 import mlte.frontend as frontend
+import mlte.web.store.main as server
 from mlte.web.store.core.config import settings
 
 # CLI exit codes

--- a/mlte/context/model/__init__.py
+++ b/mlte/context/model/__init__.py
@@ -1,10 +1,10 @@
 from .model import (
+    Model,
+    ModelCreate,
     Namespace,
     NamespaceCreate,
-    ModelCreate,
-    VersionCreate,
-    Model,
     Version,
+    VersionCreate,
 )
 
 __all__ = [

--- a/mlte/context/model/model.py
+++ b/mlte/context/model/model.py
@@ -5,6 +5,7 @@ Model implementation for MLTE context information.
 """
 
 from typing import List
+
 from mlte.model import BaseModel
 
 

--- a/mlte/frontend/__init__.py
+++ b/mlte/frontend/__init__.py
@@ -1,6 +1,6 @@
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 

--- a/mlte/measurement/__init__.py
+++ b/mlte/measurement/__init__.py
@@ -1,6 +1,6 @@
+from .external_measurement import ExternalMeasurement
 from .measurement import Measurement
 from .process_measurement import ProcessMeasurement
-from .external_measurement import ExternalMeasurement
 
 __all__ = [
     "Measurement",

--- a/mlte/measurement/cpu/__init__.py
+++ b/mlte/measurement/cpu/__init__.py
@@ -1,6 +1,6 @@
 from .local_process_cpu_utilization import (
-    LocalProcessCPUUtilization,
     CPUStatistics,
+    LocalProcessCPUUtilization,
 )
 
 __all__ = ["LocalProcessCPUUtilization", "CPUStatistics"]

--- a/mlte/measurement/cpu/local_process_cpu_utilization.py
+++ b/mlte/measurement/cpu/local_process_cpu_utilization.py
@@ -6,20 +6,18 @@ CPU utilization measurement for local training processes.
 
 from __future__ import annotations
 
-import time
 import subprocess
-from typing import Any, Type, Dict
+import time
 from subprocess import SubprocessError
+from typing import Any, Dict, Type
+
+from mlte._private.platform import is_windows
+from mlte.evidence.metadata import EvidenceMetadata
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
+from mlte.value.artifact import Value
 
 from ..process_measurement import ProcessMeasurement
-from mlte.evidence.metadata import EvidenceMetadata
-from mlte.value.artifact import Value
-from mlte.validation import (
-    Condition,
-    Success,
-    Failure,
-)
-from mlte._private.platform import is_windows
 
 # -----------------------------------------------------------------------------
 # CPUStatistics

--- a/mlte/measurement/external_measurement.py
+++ b/mlte/measurement/external_measurement.py
@@ -6,10 +6,11 @@ Base class for measurements calculated by external functions.
 
 from __future__ import annotations
 
-from typing import Type, Callable, Optional
 import typing
+from typing import Callable, Optional, Type
 
 from mlte.value.artifact import Value
+
 from .measurement import Measurement
 
 

--- a/mlte/measurement/measurement.py
+++ b/mlte/measurement/measurement.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import abc
 import typing
-from typing import Type, Optional
+from typing import Optional, Type
 
 import mlte._private.meta as meta
+from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.value.artifact import Value
 from mlte.value.types.opaque import Opaque
-from mlte.evidence.metadata import EvidenceMetadata, Identifier
 
 
 class Measurement(metaclass=abc.ABCMeta):

--- a/mlte/measurement/memory/local_process_memory_consumption.py
+++ b/mlte/measurement/memory/local_process_memory_consumption.py
@@ -6,20 +6,17 @@ Memory consumption measurement for local training processes.
 
 from __future__ import annotations
 
-import time
 import subprocess
-from typing import Any, Type, Dict
+import time
+from typing import Any, Dict, Type
+
+from mlte._private.platform import is_macos, is_windows
+from mlte.evidence.metadata import EvidenceMetadata
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
+from mlte.value.artifact import Value
 
 from ..process_measurement import ProcessMeasurement
-from mlte.evidence.metadata import EvidenceMetadata
-from mlte.value.artifact import Value
-from mlte.validation import (
-    Condition,
-    Success,
-    Failure,
-)
-from mlte._private.platform import is_windows, is_macos
-
 
 # -----------------------------------------------------------------------------
 # Memory Statistics

--- a/mlte/measurement/process_measurement.py
+++ b/mlte/measurement/process_measurement.py
@@ -10,9 +10,10 @@ import threading
 import time
 from typing import List, Optional
 
-from .measurement import Measurement
-from mlte.value.artifact import Value
 from mlte._private import job
+from mlte.value.artifact import Value
+
+from .measurement import Measurement
 
 # -----------------------------------------------------------------------------
 # ProcessMeasurement

--- a/mlte/measurement/utility/__init__.py
+++ b/mlte/measurement/utility/__init__.py
@@ -1,4 +1,4 @@
-from .execution import concurrently
 from .collection import flatten
+from .execution import concurrently
 
 __all__ = ["concurrently", "flatten"]

--- a/mlte/measurement/utility/collection.py
+++ b/mlte/measurement/utility/collection.py
@@ -4,7 +4,7 @@ mlte/measurement/utility/collection.py
 Utilities related to measurement collection.
 """
 
-from typing import Union, Any, Iterable, List
+from typing import Any, Iterable, List, Union
 
 
 def flatten(*collections: Union[Any, Iterable[Any]]) -> List[Any]:

--- a/mlte/measurement/utility/execution.py
+++ b/mlte/measurement/utility/execution.py
@@ -5,7 +5,7 @@ Utilities for execution of measurements.
 """
 
 import concurrent.futures
-from typing import Callable, Any, List
+from typing import Any, Callable, List
 
 
 def concurrently(*callables: Callable[[], Any]) -> List[Any]:

--- a/mlte/property/costs/__init__.py
+++ b/mlte/property/costs/__init__.py
@@ -1,5 +1,5 @@
 from .storage_cost import StorageCost
-from .training_memory_cost import TrainingMemoryCost
 from .training_compute_cost import TrainingComputeCost
+from .training_memory_cost import TrainingMemoryCost
 
 __all__ = ["StorageCost", "TrainingMemoryCost", "TrainingComputeCost"]

--- a/mlte/property/costs/storage_cost.py
+++ b/mlte/property/costs/storage_cost.py
@@ -4,8 +4,8 @@ mlte/property/costs/storage_cost.py
 StorageCost property definition.
 """
 
-from ..property import Property
 from ..._private.text import cleantext
+from ..property import Property
 
 
 class StorageCost(Property):

--- a/mlte/property/costs/training_compute_cost.py
+++ b/mlte/property/costs/training_compute_cost.py
@@ -4,8 +4,8 @@ mlte/property/costs/training_compute_cost.py
 TrainingComputeCost property definition.
 """
 
-from ..property import Property
 from ..._private.text import cleantext
+from ..property import Property
 
 
 class TrainingComputeCost(Property):

--- a/mlte/property/costs/training_memory_cost.py
+++ b/mlte/property/costs/training_memory_cost.py
@@ -4,8 +4,8 @@ mlte/property/costs/training_memory_cost.py
 TrainingMemoryCost property definition.
 """
 
-from ..property import Property
 from ..._private.text import cleantext
+from ..property import Property
 
 
 class TrainingMemoryCost(Property):

--- a/mlte/property/functionality/task_efficacy.py
+++ b/mlte/property/functionality/task_efficacy.py
@@ -4,8 +4,8 @@ mlte/property/functionality/task_efficacy.py
 TaskEfficacy property definition.
 """
 
-from mlte.property import Property
 from mlte._private.text import cleantext
+from mlte.property import Property
 
 
 class TaskEfficacy(Property):

--- a/mlte/property/property.py
+++ b/mlte/property/property.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import abc
 import importlib
 import pkgutil
-from typing import Type, Dict
+from typing import Dict, Type
+
 import mlte._private.meta as meta
 
 

--- a/mlte/report/__init__.py
+++ b/mlte/report/__init__.py
@@ -1,16 +1,15 @@
+from .render import render
 from .report import (
+    Considerations,
     Dataset,
-    User,
-    UseCase,
     Limitation,
     Metadata,
     ModelDetails,
     ModelSpecification,
-    Considerations,
     Report,
+    UseCase,
+    User,
 )
-
-from .render import render
 
 __all__ = [
     "Dataset",

--- a/mlte/report/html.py
+++ b/mlte/report/html.py
@@ -7,8 +7,8 @@ Utilities for HTML report generation.
 import json
 import socket
 import tempfile
+from typing import Any, Dict
 from urllib import request
-from typing import Dict, Any
 
 # The endpoint for resolving endpoints for report generation
 RESOLUTION_ENDPOINT = "https://raw.githubusercontent.com/mlte-team/mlte/master/assets/endpoints.txt"  # noqa

--- a/mlte/report/render.py
+++ b/mlte/report/render.py
@@ -7,10 +7,10 @@ Utilities for report rendering.
 import os
 import tempfile
 import webbrowser
-from typing import Union, Optional
+from typing import Optional, Union
 
-from .report import Report
 from .html import _connected
+from .report import Report
 
 
 def render(target: Union[Report, str]):

--- a/mlte/report/report.py
+++ b/mlte/report/report.py
@@ -13,17 +13,16 @@ Acknowledgements:
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import typing
-import dataclasses
 from dataclasses import dataclass, field
-from typing import List, Optional, Dict, Any, Union
+from typing import Any, Dict, List, Optional, Union
 
-from .html import _connected, _generate_html
-from ..spec import ValidatedSpec, Spec
-
-from .._private.text import cleantext
 from .._private.schema import REPORT_LATEST_SCHEMA_VERSION
+from .._private.text import cleantext
+from ..spec import Spec, ValidatedSpec
+from .html import _connected, _generate_html
 
 
 @dataclass

--- a/mlte/session/__init__.py
+++ b/mlte/session/__init__.py
@@ -1,3 +1,3 @@
-from .state import session, Session, set_context, set_store
+from .state import Session, session, set_context, set_store
 
 __all__ = ["session", "Session", "set_context", "set_store"]

--- a/mlte/spec/__init__.py
+++ b/mlte/spec/__init__.py
@@ -1,6 +1,6 @@
-from .spec import Spec
-from .validated_spec import ValidatedSpec
 from .requirement import Requirement
+from .spec import Spec
 from .spec_validator import SpecValidator
+from .validated_spec import ValidatedSpec
 
 __all__ = ["Spec", "ValidatedSpec", "Requirement", "SpecValidator"]

--- a/mlte/spec/requirement.py
+++ b/mlte/spec/requirement.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from mlte.validation import Result, Condition
-from mlte.value.artifact import Value
 from mlte.evidence.metadata import Identifier
+from mlte.validation.condition import Condition
+from mlte.validation.result import Result
+from mlte.value.artifact import Value
 
 # -----------------------------------------------------------------------------
 # Requirement

--- a/mlte/spec/spec.py
+++ b/mlte/spec/spec.py
@@ -7,12 +7,13 @@ A collection of properties and their measurements.
 from __future__ import annotations
 
 import time
-from typing import Any, Union, List, Dict
+from typing import Any, Dict, List, Union
 
-from mlte.property import Property
 from mlte._private.schema import SPEC_LATEST_SCHEMA_VERSION
-from mlte.session import session
 from mlte.api import read_spec, write_spec
+from mlte.property import Property
+from mlte.session import session
+
 from .requirement import Requirement
 
 

--- a/mlte/spec/spec_validator.py
+++ b/mlte/spec/spec_validator.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from typing import Dict
 
-from mlte.validation import Result
-from .validated_spec import ValidatedSpec
-from mlte.value.artifact import Value
 from mlte.spec import Spec
+from mlte.validation.result import Result
+from mlte.value.artifact import Value
 
+from .validated_spec import ValidatedSpec
 
 # -----------------------------------------------------------------------------
 # SpecValidator

--- a/mlte/spec/validated_spec.py
+++ b/mlte/spec/validated_spec.py
@@ -6,13 +6,12 @@ ValidatedSpec class implementation.
 
 from __future__ import annotations
 
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
-from mlte.spec import Spec
-from mlte.validation import Result
-from mlte.session import session
 from mlte.api import read_validatedspec, write_validatedspec
-
+from mlte.session import session
+from mlte.spec import Spec
+from mlte.validation.result import Result
 
 # -----------------------------------------------------------------------------
 # ValidatedSpec

--- a/mlte/store/base.py
+++ b/mlte/store/base.py
@@ -9,15 +9,15 @@ from __future__ import annotations
 from enum import Enum
 from typing import List
 
+from mlte.artifact.model import ArtifactModel
 from mlte.context.model import (
-    Namespace,
-    NamespaceCreate,
     Model,
     ModelCreate,
+    Namespace,
+    NamespaceCreate,
     Version,
     VersionCreate,
 )
-from mlte.artifact.model import ArtifactModel
 from mlte.store.query import Query
 
 # -----------------------------------------------------------------------------

--- a/mlte/store/factory.py
+++ b/mlte/store/factory.py
@@ -4,10 +4,10 @@ mlte/store/factory.py
 Top-level functions for artifact store creation.
 """
 
-from mlte.store.underlying.memory import InMemoryStore
-from mlte.store.underlying.http import RemoteHttpStore
+from mlte.store.base import Store, StoreType, StoreURI
 from mlte.store.underlying.fs import LocalFileSystemStore
-from mlte.store.base import Store, StoreURI, StoreType
+from mlte.store.underlying.http import RemoteHttpStore
+from mlte.store.underlying.memory import InMemoryStore
 
 
 def create_store(uri: str) -> Store:

--- a/mlte/store/query.py
+++ b/mlte/store/query.py
@@ -6,12 +6,12 @@ Query and filtering functionality for store operations.
 
 from __future__ import annotations
 
-from typing import Union, Literal, List
-
-from mlte.model import BaseModel
 from enum import Enum
+from typing import List, Literal, Union
+
 from mlte.artifact.model import ArtifactModel
 from mlte.artifact.type import ArtifactType
+from mlte.model import BaseModel
 
 # A type alias
 Filter = Union[

--- a/mlte/store/underlying/fs.py
+++ b/mlte/store/underlying/fs.py
@@ -4,26 +4,24 @@ mlte/store/underlying/fs.py
 Implementation of local file system artifact store.
 """
 
-from typing import Any, List, Dict
-from pathlib import Path
 import json
 import shutil
-
-from mlte.store.base import Store, StoreSession, StoreURI
-from mlte.context.model import (
-    Namespace,
-    Model,
-    Version,
-    NamespaceCreate,
-    ModelCreate,
-    VersionCreate,
-)
-from mlte.artifact.model import ArtifactModel
-from mlte.store.query import Query
-import mlte.store.util as storeutil
+from pathlib import Path
+from typing import Any, Dict, List
 
 import mlte.store.error as errors
-
+import mlte.store.util as storeutil
+from mlte.artifact.model import ArtifactModel
+from mlte.context.model import (
+    Model,
+    ModelCreate,
+    Namespace,
+    NamespaceCreate,
+    Version,
+    VersionCreate,
+)
+from mlte.store.base import Store, StoreSession, StoreURI
+from mlte.store.query import Query
 
 # The prefix that indicates a local filesystem directory is used
 LOCAL_URI_PREFIX = "local://"

--- a/mlte/store/underlying/http.py
+++ b/mlte/store/underlying/http.py
@@ -6,26 +6,26 @@ Implementation of remote HTTP artifact store.
 
 from __future__ import annotations
 
-from enum import Enum
-
 import typing
+from enum import Enum
 from typing import Any, List
+
 import requests
-import mlte.web.store.api.codes as codes
-from mlte.store.base import Store, StoreSession, StoreURI
-from mlte.context.model import (
-    Namespace,
-    Model,
-    Version,
-    NamespaceCreate,
-    ModelCreate,
-    VersionCreate,
-)
-from mlte.artifact.model import ArtifactModel
-from mlte.store.query import Query
-from mlte.web.store.api.model import WriteArtifactRequest
 
 import mlte.store.error as errors
+import mlte.web.store.api.codes as codes
+from mlte.artifact.model import ArtifactModel
+from mlte.context.model import (
+    Model,
+    ModelCreate,
+    Namespace,
+    NamespaceCreate,
+    Version,
+    VersionCreate,
+)
+from mlte.store.base import Store, StoreSession, StoreURI
+from mlte.store.query import Query
+from mlte.web.store.api.model import WriteArtifactRequest
 
 # -----------------------------------------------------------------------------
 # Client Configuration

--- a/mlte/store/underlying/memory.py
+++ b/mlte/store/underlying/memory.py
@@ -7,22 +7,21 @@ Implementation of in-memory artifact store.
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import List, Dict
-
-from mlte.store.base import Store, StoreSession, StoreURI
-from mlte.context.model import (
-    Namespace,
-    Model,
-    Version,
-    NamespaceCreate,
-    ModelCreate,
-    VersionCreate,
-)
-from mlte.artifact.model import ArtifactModel
-from mlte.store.query import Query
-import mlte.store.util as storeutil
+from typing import Dict, List
 
 import mlte.store.error as errors
+import mlte.store.util as storeutil
+from mlte.artifact.model import ArtifactModel
+from mlte.context.model import (
+    Model,
+    ModelCreate,
+    Namespace,
+    NamespaceCreate,
+    Version,
+    VersionCreate,
+)
+from mlte.store.base import Store, StoreSession, StoreURI
+from mlte.store.query import Query
 
 # -----------------------------------------------------------------------------
 # Data Structures

--- a/mlte/store/util.py
+++ b/mlte/store/util.py
@@ -5,8 +5,8 @@ Common utilities for store implementations.
 """
 
 import mlte.store.error as errors
+from mlte.context.model import ModelCreate, NamespaceCreate, VersionCreate
 from mlte.store.base import StoreSession
-from mlte.context.model import NamespaceCreate, ModelCreate, VersionCreate
 
 
 def create_parents(

--- a/mlte/validation/__init__.py
+++ b/mlte/validation/__init__.py
@@ -1,4 +1,0 @@
-from .result import Result, Success, Failure, Ignore
-from .condition import Condition
-
-__all__ = ["Result", "Success", "Failure", "Ignore", "Condition"]

--- a/mlte/validation/condition.py
+++ b/mlte/validation/condition.py
@@ -6,14 +6,14 @@ The interface for measurement validation.
 
 from __future__ import annotations
 
-import typing
-from typing import Callable, Any, List, Dict
 import base64
+import typing
+from typing import Any, Callable, Dict, List
 
 import dill
 
+from mlte.validation.result import Result
 from mlte.value.artifact import Value
-from . import Result
 
 
 class Condition:

--- a/mlte/validation/result.py
+++ b/mlte/validation/result.py
@@ -7,11 +7,11 @@ The result of measurement validation.
 from __future__ import annotations
 
 import abc
-from typing import Optional, Any, Dict
 import sys
+from typing import Any, Dict, Optional
 
-from mlte.evidence.metadata import EvidenceMetadata
 import mlte._private.meta as meta
+from mlte.evidence.metadata import EvidenceMetadata
 
 # -----------------------------------------------------------------------------
 # Validation Results

--- a/mlte/value/types/image.py
+++ b/mlte/value/types/image.py
@@ -14,7 +14,8 @@ from typing import Union
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
-from mlte.validation import Condition, Ignore
+from mlte.validation.condition import Condition
+from mlte.validation.result import Ignore
 from mlte.value.artifact import Value
 from mlte.value.model import ImageValueModel, ValueModel, ValueType
 

--- a/mlte/value/types/integer.py
+++ b/mlte/value/types/integer.py
@@ -11,7 +11,8 @@ import typing
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
-from mlte.validation import Condition, Failure, Success
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
 from mlte.value.artifact import Value
 from mlte.value.model import IntegerValueModel, ValueModel, ValueType
 

--- a/mlte/value/types/real.py
+++ b/mlte/value/types/real.py
@@ -11,7 +11,8 @@ import typing
 from mlte.artifact.model import ArtifactHeaderModel, ArtifactModel
 from mlte.artifact.type import ArtifactType
 from mlte.evidence.metadata import EvidenceMetadata
-from mlte.validation import Condition, Failure, Success
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
 from mlte.value.artifact import Value
 from mlte.value.model import RealValueModel, ValueModel, ValueType
 

--- a/test/measurement/cpu/test_local_process_cpu_utilization.py
+++ b/test/measurement/cpu/test_local_process_cpu_utilization.py
@@ -14,7 +14,8 @@ import pytest
 
 from mlte._private.platform import is_nix, is_windows
 from mlte.measurement.cpu import CPUStatistics, LocalProcessCPUUtilization
-from mlte.validation import Condition, Failure, Success
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
 
 from ...support.meta import path_to_support
 

--- a/test/measurement/memory/test_local_process_memory_consumption.py
+++ b/test/measurement/memory/test_local_process_memory_consumption.py
@@ -16,7 +16,8 @@ from mlte.measurement.memory import (
     LocalProcessMemoryConsumption,
     MemoryStatistics,
 )
-from mlte.validation import Condition, Failure, Success
+from mlte.validation.condition import Condition
+from mlte.validation.result import Failure, Success
 
 from ...support.meta import path_to_support
 

--- a/test/measurement/storage/test_local_object_size.py
+++ b/test/measurement/storage/test_local_object_size.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from mlte.measurement.storage import LocalObjectSize
-from mlte.validation import Result
+from mlte.validation.result import Result
 from mlte.value.types.integer import Integer
 
 # -----------------------------------------------------------------------------

--- a/test/schema/test_report_schema.py
+++ b/test/schema/test_report_schema.py
@@ -12,7 +12,7 @@ from jsonschema import ValidationError
 from mlte._private.schema import validate_report_schema
 from mlte.report import Dataset, Limitation, Report, UseCase, User
 from mlte.spec import Spec, ValidatedSpec
-from mlte.validation import Ignore
+from mlte.validation.result import Ignore
 
 
 @pytest.mark.skip("Pending artifact protocol implementation.")

--- a/test/spec/test_validatedspec.py
+++ b/test/spec/test_validatedspec.py
@@ -14,7 +14,7 @@ from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.measurement.storage import LocalObjectSize
 from mlte.property.costs import StorageCost
 from mlte.spec import Requirement, Spec, SpecValidator, ValidatedSpec
-from mlte.validation import Result
+from mlte.validation.result import Result
 from mlte.value.types.integer import Integer
 
 


### PR DESCRIPTION
Resolves #204.

This PR integrates the `isort` tool for import sorting across all MLTE source. I had been trying to integrate this slowly across sub-packages within MLTE. I finally fixed the underlying circular import issues that now allow this tool to be fully integrated. Furthermore, the tool is integrated with our CI pipeline.