### PR TITLE
Bump Pydantic

### DIFF
--- a/mlte/model/base_model.py
+++ b/mlte/model/base_model.py
@@ -19,7 +19,7 @@ class BaseModel(pydantic.BaseModel):
         Serialize the model.
         :return: The JSON representation of the model
         """
-        return self.dict()
+        return self.model_dump()
 
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> BaseModel:

--- a/mlte/store/underlying/fs.py
+++ b/mlte/store/underlying/fs.py
@@ -310,7 +310,7 @@ class LocalFileSystemStoreSession(StoreSession):
             self._artifact_path(
                 namespace_id, model_id, version_id, artifact.header.identifier
             ),
-            artifact.dict(),
+            artifact.model_dump(),
         )
         return artifact
 

--- a/mlte/store/underlying/http.py
+++ b/mlte/store/underlying/http.py
@@ -102,7 +102,7 @@ class RemoteHttpStoreSession(StoreSession):
 
     def create_namespace(self, namespace: NamespaceCreate) -> Namespace:
         url = f"{self.url}/api/namespace"
-        res = self.client.post(url, json=namespace.dict())
+        res = self.client.post(url, json=namespace.model_dump())
         raise_for_response(res)
 
         return Namespace(**res.json())
@@ -130,7 +130,7 @@ class RemoteHttpStoreSession(StoreSession):
 
     def create_model(self, namespace_id: str, model: ModelCreate) -> Model:
         url = f"{self.url}/api/namespace/{namespace_id}/model"
-        res = self.client.post(url, json=model.dict())
+        res = self.client.post(url, json=model.model_dump())
         raise_for_response(res)
 
         return Model(**res.json())
@@ -162,7 +162,7 @@ class RemoteHttpStoreSession(StoreSession):
         url = (
             f"{self.url}/api/namespace/{namespace_id}/model/{model_id}/version"
         )
-        res = self.client.post(url, json=version.dict())
+        res = self.client.post(url, json=version.model_dump())
         raise_for_response(res)
 
         return Version(**res.json())
@@ -212,7 +212,7 @@ class RemoteHttpStoreSession(StoreSession):
             url,
             json=WriteArtifactRequest(
                 artifact=artifact, parents=parents
-            ).dict(),
+            ).model_dump(),
         )
         raise_for_response(res)
 
@@ -254,7 +254,7 @@ class RemoteHttpStoreSession(StoreSession):
     ) -> List[ArtifactModel]:
         # NOTE(Kyle): This operation always uses the "advanced search" functionality
         url = f"{_url(self.url, namespace_id, model_id, version_id)}/artifact/search"
-        res = self.client.post(url, json=query.dict())
+        res = self.client.post(url, json=query.model_dump())
         raise_for_response(res)
 
         return [ArtifactModel(**object) for object in res.json()]

--- a/mlte/web/store/core/config.py
+++ b/mlte/web/store/core/config.py
@@ -6,8 +6,8 @@ Configuration management for FastAPI application.
 
 from __future__ import annotations
 
-from pydantic import validator
-from pydantic_settings import BaseSettings
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # An enumeration of supported log levels
 _LOG_LEVELS = ["DEBUG", "WARNING", "INFO", "ERROR", "CRITICAL"]
@@ -29,7 +29,8 @@ class Settings(BaseSettings):
     APP_PORT: str = "8080"
     """The port to which the server binds."""
 
-    @validator("APP_PORT", pre=True)
+    @field_validator("APP_PORT", mode="before")
+    @classmethod
     def validate_app_port(cls, v: str) -> str:
         try:
             int(v)
@@ -45,14 +46,14 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "ERROR"
     """The application log level; defaults to ERROR."""
 
-    @validator("LOG_LEVEL", pre=True)
+    @field_validator("LOG_LEVEL", mode="before")
+    @classmethod
     def validate_log_level(cls, v: str) -> str:
         if v not in _LOG_LEVELS:
             raise ValueError(f"Unsupported log level: {v}.")
         return v
 
-    class Config:
-        case_sensitive = True
+    model_config = SettingsConfigDict(case_sensitive=True)
 
 
 # The exported settings object

--- a/test/store/test_query.py
+++ b/test/store/test_query.py
@@ -23,7 +23,7 @@ from ..fixture.artifact import ArtifactFactory, TypeUtil
 def test_all() -> None:
     """The all filter can be serialized and deserialized."""
     f = AllFilter(type=FilterType.ALL)
-    assert AllFilter(**f.dict()) == f
+    assert AllFilter(**f.model_dump()) == f
 
 
 @pytest.mark.parametrize("artifact_type", ArtifactType)
@@ -36,7 +36,7 @@ def test_all_match(artifact_type: ArtifactType) -> None:
 def test_none() -> None:
     """The all filter cna be serialized and deserialized."""
     f = NoneFilter(type=FilterType.NONE)
-    assert NoneFilter(**f.dict()) == f
+    assert NoneFilter(**f.model_dump()) == f
 
 
 @pytest.mark.parametrize("artifact_type", ArtifactType)
@@ -49,7 +49,7 @@ def test_none_match(artifact_type: ArtifactType) -> None:
 def test_identifier() -> None:
     """The identifier filter can be serialized and deserialized."""
     f = ArtifactIdentifierFilter(type=FilterType.IDENTIFIER, artifact_id="id0")
-    assert ArtifactIdentifierFilter(**f.dict()) == f
+    assert ArtifactIdentifierFilter(**f.model_dump()) == f
 
 
 @pytest.mark.parametrize("artifact_type", ArtifactType)
@@ -70,7 +70,7 @@ def test_type() -> None:
     f = ArtifactTypeFilter(
         type=FilterType.TYPE, artifact_type=ArtifactType.NEGOTIATION_CARD
     )
-    assert ArtifactTypeFilter(**f.dict()) == f
+    assert ArtifactTypeFilter(**f.model_dump()) == f
 
 
 @pytest.mark.parametrize("artifact_type", ArtifactType)
@@ -97,7 +97,7 @@ def test_and() -> None:
             NoneFilter(type=FilterType.NONE),
         ],
     )
-    assert AndFilter(**f.dict()) == f
+    assert AndFilter(**f.model_dump()) == f
 
 
 @pytest.mark.skip("Implement.")
@@ -119,7 +119,7 @@ def test_or() -> None:
             ),
         ],
     )
-    assert OrFilter(**f.dict()) == f
+    assert OrFilter(**f.model_dump()) == f
 
 
 @pytest.mark.skip("Implement.")

--- a/test/web/store/context/test_model.py
+++ b/test/web/store/context/test_model.py
@@ -36,7 +36,7 @@ def test_create(
 
     model = ModelCreate(identifier="model")
 
-    res = client.post("/api/namespace/0/model", json=model.dict())
+    res = client.post("/api/namespace/0/model", json=model.model_dump())
     assert res.status_code == 200
     _ = Model(**res.json())
 
@@ -50,7 +50,7 @@ def test_read(
     create_namespace("0", client)
 
     model = ModelCreate(identifier="0")
-    res = client.post("/api/namespace/0/model", json=model.dict())
+    res = client.post("/api/namespace/0/model", json=model.model_dump())
     assert res.status_code == 200
 
     created = Model(**res.json())
@@ -71,7 +71,7 @@ def test_list(
 
     model = ModelCreate(identifier="0")
 
-    res = client.post("/api/namespace/0/model", json=model.dict())
+    res = client.post("/api/namespace/0/model", json=model.model_dump())
     assert res.status_code == 200
 
     res = client.get("/api/namespace/0/model")
@@ -89,7 +89,7 @@ def test_delete(
 
     model = ModelCreate(identifier="0")
 
-    res = client.post("/api/namespace/0/model", json=model.dict())
+    res = client.post("/api/namespace/0/model", json=model.model_dump())
     assert res.status_code == 200
 
     res = client.get("/api/namespace/0/model")
@@ -107,6 +107,6 @@ def test_delete(
 def create_namespace(id: str, client: TestClient) -> None:
     """Create a namespace with the given identifier."""
     res = client.post(
-        "/api/namespace", json=NamespaceCreate(identifier=id).dict()
+        "/api/namespace", json=NamespaceCreate(identifier=id).model_dump()
     )
     assert res.status_code == 200

--- a/test/web/store/context/test_namespace.py
+++ b/test/web/store/context/test_namespace.py
@@ -35,7 +35,7 @@ def test_create(
 
     ns = NamespaceCreate(identifier="id")
 
-    res = client.post("/api/namespace", json=ns.dict())
+    res = client.post("/api/namespace", json=ns.model_dump())
     assert res.status_code == 200
     _ = Namespace(**res.json())
 
@@ -49,7 +49,7 @@ def test_read(
 
     ns = NamespaceCreate(identifier="id")
 
-    res = client.post("/api/namespace", json=ns.dict())
+    res = client.post("/api/namespace", json=ns.model_dump())
     assert res.status_code == 200
     created = Namespace(**res.json())
 
@@ -68,7 +68,7 @@ def test_list(
 
     ns = NamespaceCreate(identifier="id")
 
-    res = client.post("/api/namespace", json=ns.dict())
+    res = client.post("/api/namespace", json=ns.model_dump())
     assert res.status_code == 200
 
     res = client.get("/api/namespace")
@@ -85,7 +85,7 @@ def test_delete(
 
     ns = NamespaceCreate(identifier="id")
 
-    res = client.post("/api/namespace", json=ns.dict())
+    res = client.post("/api/namespace", json=ns.model_dump())
     assert res.status_code == 200
 
     res = client.get("/api/namespace")

--- a/test/web/store/context/test_version.py
+++ b/test/web/store/context/test_version.py
@@ -37,7 +37,9 @@ def test_create(
 
     version = VersionCreate(identifier="0")
 
-    res = client.post("/api/namespace/0/model/0/version", json=version.dict())
+    res = client.post(
+        "/api/namespace/0/model/0/version", json=version.model_dump()
+    )
     assert res.status_code == 200
     _ = Version(**res.json())
 
@@ -51,7 +53,9 @@ def test_read(
     create_namespace_and_model("0", "0", client)
 
     version = VersionCreate(identifier="0")
-    res = client.post("/api/namespace/0/model/0/version", json=version.dict())
+    res = client.post(
+        "/api/namespace/0/model/0/version", json=version.model_dump()
+    )
     assert res.status_code == 200
 
     created = Version(**res.json())
@@ -71,7 +75,9 @@ def test_list(
     create_namespace_and_model("0", "0", client)
 
     version = VersionCreate(identifier="0")
-    res = client.post("/api/namespace/0/model/0/version", json=version.dict())
+    res = client.post(
+        "/api/namespace/0/model/0/version", json=version.model_dump()
+    )
     assert res.status_code == 200
 
     res = client.get("/api/namespace/0/model/0/version")
@@ -88,7 +94,9 @@ def test_delete(
     create_namespace_and_model("0", "0", client)
 
     version = VersionCreate(identifier="0")
-    res = client.post("/api/namespace/0/model/0/version", json=version.dict())
+    res = client.post(
+        "/api/namespace/0/model/0/version", json=version.model_dump()
+    )
     assert res.status_code == 200
 
     res = client.get("/api/namespace/0/model/0/version")
@@ -108,12 +116,13 @@ def create_namespace_and_model(
 ) -> None:
     """Create a namespace and model with the given identifiers."""
     res = client.post(
-        "/api/namespace", json=NamespaceCreate(identifier=namespace_id).dict()
+        "/api/namespace",
+        json=NamespaceCreate(identifier=namespace_id).model_dump(),
     )
     assert res.status_code == 200
 
     res = client.post(
         f"/api/namespace/{namespace_id}/model",
-        json=ModelCreate(identifier=model_id).dict(),
+        json=ModelCreate(identifier=model_id).model_dump(),
     )
     assert res.status_code == 200

--- a/test/web/store/test_artifact.py
+++ b/test/web/store/test_artifact.py
@@ -45,7 +45,7 @@ def test_write(
     r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=r.dict(),
+        json=r.model_dump(),
     )
     assert res.status_code == 200
 
@@ -66,7 +66,7 @@ def test_read(
     r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=r.dict(),
+        json=r.model_dump(),
     )
     assert res.status_code == 200
     artifact = res.json()["artifact"]
@@ -96,7 +96,7 @@ def test_search(
     r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=r.dict(),
+        json=r.model_dump(),
     )
     assert res.status_code == 200
     artifact = res.json()["artifact"]
@@ -104,7 +104,7 @@ def test_search(
 
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact/search",
-        json=Query().dict(),
+        json=Query().model_dump(),
     )
     assert res.status_code == 200
 
@@ -131,7 +131,7 @@ def test_delete(
     r = WriteArtifactRequest(artifact=a, parents=False)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
-        json=r.dict(),
+        json=r.model_dump(),
     )
     assert res.status_code == 200
 
@@ -156,18 +156,19 @@ def create_context(
 ) -> None:
     """Create context for artifacts.."""
     res = client.post(
-        "/api/namespace", json=NamespaceCreate(identifier=namespace_id).dict()
+        "/api/namespace",
+        json=NamespaceCreate(identifier=namespace_id).model_dump(),
     )
     assert res.status_code == 200
 
     res = client.post(
         f"/api/namespace/{namespace_id}/model",
-        json=ModelCreate(identifier=model_id).dict(),
+        json=ModelCreate(identifier=model_id).model_dump(),
     )
     assert res.status_code == 200
 
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version",
-        json=VersionCreate(identifier=version_id).dict(),
+        json=VersionCreate(identifier=version_id).model_dump(),
     )
     assert res.status_code == 200


### PR DESCRIPTION
- Resolves #220.
- Resolves #221.

This PR utilizes `bump-pydantic` to bump us from deprecated usage of Pydantic across the codebase. Changes are localized to a single file. With this merge, all warnings from unit test execution are clear.