### PR TITLE
Implement Versioning Semantics for Artifact Store

### DIFF
--- a/mlte/artifact/artifact.py
+++ b/mlte/artifact/artifact.py
@@ -57,25 +57,34 @@ class Artifact(metaclass=abc.ABCMeta):
             "Artifact.from_model() not implemented for abstract Artifact."
         )
 
-    def save(self, *, parents: bool = False) -> None:
+    def save(self, *, force: bool = False, parents: bool = False) -> None:
         """
         Save an artifact with parameters from the configured global session.
 
         This is equivalent to calling:
             artifact.save_with(session().context, session().store)
 
+        :param force: Indicates that an existing artifact may be overwritten
         :param parents: Indicates whether organizational elements for the
         artifact are created implicitly on write (default: False)
         """
-        self.save_with(session().context, session().store, parents=parents)
+        self.save_with(
+            session().context, session().store, force=force, parents=parents
+        )
 
     def save_with(
-        self, context: Context, store: Store, *, parents: bool = False
+        self,
+        context: Context,
+        store: Store,
+        *,
+        force: bool = False,
+        parents: bool = False,
     ) -> None:
         """
         Save an artifact with the given context and store configuration.
         :param context: The context in which to save the artifact
         :param store: The store in which to save the artifact
+        :param force: Indicates that an existing artifact may be overwritten
         :param parents: Indicates whether organizational elements for the
         artifact are created implicitly on write (default: False)
         """
@@ -85,6 +94,7 @@ class Artifact(metaclass=abc.ABCMeta):
                 context.model,
                 context.version,
                 self.to_model(),
+                force=force,
                 parents=parents,
             )
 

--- a/mlte/store/base.py
+++ b/mlte/store/base.py
@@ -242,6 +242,7 @@ class StoreSession:
         version_id: str,
         artifact: ArtifactModel,
         *,
+        force: bool = False,
         parents: bool = False,
     ) -> ArtifactModel:
         """
@@ -250,6 +251,7 @@ class StoreSession:
         :param model_id: The identifier for the model
         :param version_id: The identifier for the model version
         :param artifact: The artifact
+        :param force: Overwrite an artifact if it already exists
         :param parents: Indicates whether organizational elements
         for artifact should be implictly created (default: False)
         """

--- a/mlte/store/underlying/fs.py
+++ b/mlte/store/underlying/fs.py
@@ -293,6 +293,7 @@ class LocalFileSystemStoreSession(StoreSession):
         version_id: str,
         artifact: ArtifactModel,
         *,
+        force: bool = False,
         parents: bool = False,
     ) -> ArtifactModel:
         if parents:
@@ -301,7 +302,7 @@ class LocalFileSystemStoreSession(StoreSession):
         artifacts = self._get_version_artifacts(
             namespace_id, model_id, version_id
         )
-        if artifact.header.identifier in artifacts:
+        if artifact.header.identifier in artifacts and not force:
             raise errors.ErrorAlreadyExists(
                 f"Artifact '{artifact.header.identifier}'"
             )

--- a/mlte/store/underlying/http.py
+++ b/mlte/store/underlying/http.py
@@ -212,7 +212,7 @@ class RemoteHttpStoreSession(StoreSession):
         res = self.client.post(
             url,
             json=WriteArtifactRequest(
-                artifact=artifact, parents=parents
+                artifact=artifact, force=force, parents=parents
             ).model_dump(),
         )
         raise_for_response(res)

--- a/mlte/store/underlying/http.py
+++ b/mlte/store/underlying/http.py
@@ -205,13 +205,14 @@ class RemoteHttpStoreSession(StoreSession):
         version_id: str,
         artifact: ArtifactModel,
         *,
+        force: bool = False,
         parents: bool = False,
     ) -> ArtifactModel:
         url = f"{_url(self.url, namespace_id, model_id, version_id)}/artifact"
         res = self.client.post(
             url,
             json=WriteArtifactRequest(
-                artifact=artifact, parents=parents
+                artifact=artifact, force=force, parents=parents
             ).dict(),
         )
         raise_for_response(res)

--- a/mlte/store/underlying/memory.py
+++ b/mlte/store/underlying/memory.py
@@ -291,6 +291,7 @@ class InMemoryStoreSession(StoreSession):
         version_id: str,
         artifact: ArtifactModel,
         *,
+        force: bool = False,
         parents: bool = False,
     ) -> ArtifactModel:
         if parents:
@@ -300,7 +301,7 @@ class InMemoryStoreSession(StoreSession):
             namespace_id, model_id, version_id
         )
 
-        if artifact.header.identifier in version.artifacts:
+        if artifact.header.identifier in version.artifacts and not force:
             raise errors.ErrorAlreadyExists(
                 f"Artifact '{artifact.header.identifier}'"
             )

--- a/mlte/web/store/api/endpoints/artifact.py
+++ b/mlte/web/store/api/endpoints/artifact.py
@@ -43,6 +43,7 @@ def write_artifact(
                 model_id,
                 version_id,
                 request.artifact,
+                force=request.force,
                 parents=request.parents,
             )
             return WriteArtifactResponse(artifact=artifact)

--- a/mlte/web/store/api/model.py
+++ b/mlte/web/store/api/model.py
@@ -19,7 +19,10 @@ class WriteArtifactRequest(BaseModel):
     artifact: ArtifactModel
     """The model for the artifact to write."""
 
-    parents: bool
+    force: bool = False
+    """Indicates that existing artifacts may be overwritten."""
+
+    parents: bool = False
     """Indicates whether organizational elements should be created."""
 
 

--- a/test/negotiation/test_artifact.py
+++ b/test/negotiation/test_artifact.py
@@ -83,3 +83,19 @@ def test_save_parents(store: Store) -> None:
 
     card = NegotiationCard("my-card")
     card.save_with(ctx, store, parents=True)
+
+
+def test_save_overwrite(store_with_context: Tuple[Store, Context]) -> None:
+    """Save succeeds when old artifact is overwritten."""
+    store, ctx = store_with_context
+
+    # Initial write succeeds
+    card = NegotiationCard("my-card")
+    card.save_with(ctx, store)
+
+    # Write without `force` fails
+    with pytest.raises(errors.ErrorAlreadyExists):
+        card.save_with(ctx, store)
+
+    # Force write succeeds
+    card.save_with(ctx, store, force=True)

--- a/test/web/store/test_artifact.py
+++ b/test/web/store/test_artifact.py
@@ -42,7 +42,7 @@ def test_write(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type)
-    r = WriteArtifactRequest(artifact=a, parents=False)
+    r = WriteArtifactRequest(artifact=a)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
         json=r.dict(),
@@ -63,7 +63,7 @@ def test_read(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type, id="id0")
-    r = WriteArtifactRequest(artifact=a, parents=False)
+    r = WriteArtifactRequest(artifact=a)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
         json=r.dict(),
@@ -93,7 +93,7 @@ def test_search(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type)
-    r = WriteArtifactRequest(artifact=a, parents=False)
+    r = WriteArtifactRequest(artifact=a)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
         json=r.dict(),
@@ -128,7 +128,7 @@ def test_delete(
     create_context(namespace_id, model_id, version_id, client)
 
     a = ArtifactFactory.make(artifact_type, "id0")
-    r = WriteArtifactRequest(artifact=a, parents=False)
+    r = WriteArtifactRequest(artifact=a)
     res = client.post(
         f"/api/namespace/{namespace_id}/model/{model_id}/version/{version_id}/artifact",
         json=r.dict(),


### PR DESCRIPTION
- Resolves #171 
- Resolves #178 

We determined that the current way forward with artifact versioning and write semantics is as follows:

- By default, attempts to overwrite existing artifacts fail with `ErrorAlreadyExists`
- Clients can opt-in to overwrite behavior with the use of optional parameters in MLTE clients

This behavior is important for interactions in the web UI. Here, users will be interested in iterative development of the content in specific artifacts, like the negotiation card and the report. We don't want users to have to create a new version of the artifact every time they enter some new text and hit "save." Therefore, the frontend will implicitly use this overwrite functionality when an existing artifact is edited.

This functionality is exposed by the artifact protocol. It is now possible to write artifacts that overwrite existing instances as follows:

```python
card = NegotiationCard("my-card")
card.save(force=True)
```