### PR TITLE
Add CORS Configuration Option to Artifact Store

### DIFF
--- a/mlte/cli/cli.py
+++ b/mlte/cli/cli.py
@@ -6,6 +6,7 @@ Top-level command line interface.
 
 import argparse
 import sys
+import traceback
 
 import mlte.frontend as frontend
 import mlte.web.store.main as server
@@ -96,6 +97,9 @@ def run():
     except KeyError:
         parser.print_help()
         return EXIT_SUCCESS
+    except Exception:
+        traceback.print_exc()
+        return EXIT_FAILURE
 
 
 if __name__ == "__main__":

--- a/mlte/cli/cli.py
+++ b/mlte/cli/cli.py
@@ -59,8 +59,14 @@ def _attach_store(
     parser.add_argument(
         "--backend-uri",
         type=str,
-        required=True,
-        help="The URI for the backend store.",
+        default=settings.BACKEND_URI,
+        help=f"The URI for the backend store (default: {settings.BACKEND_URI}).",
+    )
+    parser.add_argument(
+        "--allowed-origins",
+        nargs="*",
+        default=settings.ALLOWED_ORIGINS,
+        help=f"A list of allowed CORS origins (default: {settings.ALLOWED_ORIGINS})",
     )
 
 

--- a/mlte/web/store/app_factory.py
+++ b/mlte/web/store/app_factory.py
@@ -4,19 +4,14 @@ mlte/web/store/app_factory.py
 Web application factory.
 """
 
-from typing import List
-
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic.networks import HttpUrl
 
 from mlte.web.store.core.config import settings
 
 
-def create(*, allowed_origins: List[HttpUrl] = []) -> FastAPI:
+def create() -> FastAPI:
     """
     Create an instance of the application.
-    :param allowed_origins: A collection of allowed origins
     :return: The app
     """
     app = FastAPI(
@@ -24,12 +19,5 @@ def create(*, allowed_origins: List[HttpUrl] = []) -> FastAPI:
         docs_url=f"{settings.API_PREFIX}/docs",
         redoc_url=f"{settings.API_PREFIX}/redoc",
         openapi_url=f"{settings.API_PREFIX}/openapi.json",
-    )
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=[str(url) for url in allowed_origins],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
     )
     return app

--- a/mlte/web/store/app_factory.py
+++ b/mlte/web/store/app_factory.py
@@ -4,16 +4,32 @@ mlte/web/store/app_factory.py
 Web application factory.
 """
 
+from typing import List
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic.networks import HttpUrl
 
 from mlte.web.store.core.config import settings
 
 
-def create() -> FastAPI:
-    """Create an instance of the application."""
-    return FastAPI(
+def create(*, allowed_origins: List[HttpUrl] = []) -> FastAPI:
+    """
+    Create an instance of the application.
+    :param allowed_origins: A collection of allowed origins
+    :return: The app
+    """
+    app = FastAPI(
         title="MLTE Artifact Store",
         docs_url=f"{settings.API_PREFIX}/docs",
         redoc_url=f"{settings.API_PREFIX}/redoc",
         openapi_url=f"{settings.API_PREFIX}/openapi.json",
     )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[str(url) for url in allowed_origins],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app

--- a/mlte/web/store/core/config.py
+++ b/mlte/web/store/core/config.py
@@ -6,6 +6,8 @@ Configuration management for FastAPI application.
 
 from __future__ import annotations
 
+from typing import List
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -52,6 +54,9 @@ class Settings(BaseSettings):
         if v not in _LOG_LEVELS:
             raise ValueError(f"Unsupported log level: {v}.")
         return v
+
+    ALLOWED_ORIGINS: List[str] = []
+    """A list of allowed CORS origins."""
 
     model_config = SettingsConfigDict(case_sensitive=True)
 


### PR DESCRIPTION
- Resolves #244 

This PR adds a configuration option to the artifact store to accept allowed CORS origins. The configuration is specified via the commandline:

```bash
mlte store --allowed-origins http://localhost:9000
```

or via the environment:

```bash
ALLOWED_ORIGINS='["http://localhost:9000"]' mlte store
```