### PR TITLE
Fixed CPUStatistics and MemoryStatistics, demo, and schema tests

### DIFF
--- a/demo/confusion_matrix.py
+++ b/demo/confusion_matrix.py
@@ -6,9 +6,10 @@ Implementation of ConfusionMatrix value.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
+import pandas as pd
 
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.spec.condition import Condition
@@ -26,13 +27,15 @@ class ConfusionMatrix(ValueBase):
         """Underlying matrix represented as two-dimensional array."""
 
     def serialize(self) -> Dict[str, Any]:
-        return {"matrix": self.matrix}
+        return {"matrix": pd.DataFrame(self.matrix).to_json()}
 
     @staticmethod
     def deserialize(
         metadata: EvidenceMetadata, data: Dict[str, Any]
     ) -> ConfusionMatrix:
-        return ConfusionMatrix(metadata, data["matrix"])
+        return ConfusionMatrix(
+            metadata, pd.read_json(data["matrix"]).to_numpy()
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ConfusionMatrix):

--- a/demo/evidence.ipynb
+++ b/demo/evidence.ipynb
@@ -119,7 +119,7 @@
     "os.makedirs(store_path, exist_ok=True)   # Ensure we are creating the folder if it is not there.\n",
     "\n",
     "set_context(\"ns\", \"IrisClassifier\", \"0.0.1\")\n",
-    "set_store(\"memory://\")"
+    "set_store(f\"local://{store_path}\")"
    ]
   },
   {
@@ -150,7 +150,7 @@
     "print(size)\n",
     "\n",
     "# Save to artifact store\n",
-    "size.save()"
+    "size.save(force=True)"
    ]
   },
   {
@@ -202,7 +202,7 @@
     "print(cpu_stats)\n",
     "\n",
     "# Save to artifact store\n",
-    "cpu_stats.save()"
+    "cpu_stats.save(force=True)"
    ]
   },
   {
@@ -230,7 +230,7 @@
     "print(mem_stats)\n",
     "\n",
     "# Save to artifact store\n",
-    "mem_stats.save()"
+    "mem_stats.save(force=True)"
    ]
   },
   {
@@ -269,8 +269,8 @@
     "print(mem_stats)\n",
     "\n",
     "# Save to artifact store\n",
-    "cpu_stats.save()\n",
-    "mem_stats.save()"
+    "cpu_stats.save(force=True)\n",
+    "mem_stats.save(force=True)"
    ]
   },
   {
@@ -326,7 +326,7 @@
     "print(accuracy)\n",
     "\n",
     "# Save to artifact store\n",
-    "accuracy.save(parents=True)"
+    "accuracy.save(force=True)"
    ]
   },
   {
@@ -355,7 +355,7 @@
     "print(matrix)\n",
     "\n",
     "# Save to artifact store\n",
-    "matrix.save(parents=True)"
+    "matrix.save(force=True)"
    ]
   },
   {
@@ -390,7 +390,7 @@
     "img_collector = ExternalMeasurement(\"class distribution\", Image)\n",
     "img = img_collector.ingest(MEDIA_DIR / \"classes.png\")\n",
     "\n",
-    "img.save()"
+    "img.save(force=True)"
    ]
   }
  ],

--- a/demo/report.ipynb
+++ b/demo/report.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "#f\"local://{store_path}\"\n",
     "set_context(\"ns\", \"IrisClassifier\", \"0.0.1\")\n",
-    "set_store(\"memory://\")"
+    "set_store(f\"local://{store_path}\")"
    ]
   },
   {
@@ -79,7 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mlte.spec import Spec, SpecValidator\n",
+    "from mlte.spec.spec import Spec\n",
+    "from mlte.validation.spec_validator import SpecValidator\n",
     "from mlte.value.types.integer import Integer\n",
     "from mlte.value.types.real import Real\n",
     "from mlte.value.types.image import Image\n",
@@ -94,12 +95,12 @@
     "\n",
     "# Add all values to the validator.\n",
     "spec_validator = SpecValidator(spec)\n",
-    "spec_validator.add_value(Integer.load(\"model size\"))\n",
-    "spec_validator.add_value(CPUStatistics.load(\"training cpu\"))\n",
-    "spec_validator.add_value(MemoryStatistics.load(\"training memory\"))\n",
-    "spec_validator.add_value(Real.load(\"accuracy\"))\n",
-    "spec_validator.add_value(ConfusionMatrix.load(\"confusion matrix\"))\n",
-    "spec_validator.add_value(Image.load(\"class distribution\"))"
+    "spec_validator.add_value(Integer.load(\"model size.value\"))\n",
+    "spec_validator.add_value(CPUStatistics.load(\"training cpu.value\"))\n",
+    "spec_validator.add_value(MemoryStatistics.load(\"training memory.value\"))\n",
+    "spec_validator.add_value(Real.load(\"accuracy.value\"))\n",
+    "spec_validator.add_value(ConfusionMatrix.load(\"confusion matrix.value\"))\n",
+    "spec_validator.add_value(Image.load(\"class distribution.value\"))"
    ]
   },
   {
@@ -112,7 +113,7 @@
     "validated_spec = spec_validator.validate()\n",
     "\n",
     "# ValidatedSpec also supports persistence\n",
-    "validated_spec.save()"
+    "validated_spec.save(force=True)"
    ]
   },
   {

--- a/mlte/_private/schema.py
+++ b/mlte/_private/schema.py
@@ -146,7 +146,7 @@ def _find_schema(version: str, subdirectory: str) -> Dict[str, Any]:
     """
     # Construct the path to the schema file
     path = os.path.join(
-        "schema", subdirectory, f"v{version}", _SCHEMA_FILE_NAME
+        "schema", "artifact", subdirectory, f"v{version}", _SCHEMA_FILE_NAME
     )
     # Locate the artifact, load, and return it
     data = pkgutil.get_data("mlte", path)
@@ -209,7 +209,7 @@ def _find_validatedspec_schema(version: Optional[str] = None) -> Dict[str, Any]:
         version = VALIDATEDSPEC_LATEST_SCHEMA_VERSION
     if version not in _VALIDATEDSPEC_SCHEMA_VERSIONS:
         raise ValueError(f"Invalid spec schema version {version} specified.")
-    return _find_schema(version, "validatedspec")
+    return _find_schema(version, "validated")
 
 
 def _find_report_schema(version: Optional[str] = None):

--- a/mlte/measurement/cpu/local_process_cpu_utilization.py
+++ b/mlte/measurement/cpu/local_process_cpu_utilization.py
@@ -15,7 +15,7 @@ from mlte._private.platform import is_windows
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.spec.condition import Condition
 from mlte.validation.result import Failure, Success
-from mlte.value.artifact import Value
+from mlte.value.base import ValueBase
 
 from ..process_measurement import ProcessMeasurement
 
@@ -24,7 +24,7 @@ from ..process_measurement import ProcessMeasurement
 # -----------------------------------------------------------------------------
 
 
-class CPUStatistics(Value):
+class CPUStatistics(ValueBase):
     """
     The CPUStatistics class encapsulates data
     and functionality for tracking and updating
@@ -42,13 +42,9 @@ class CPUStatistics(Value):
         Initialize a CPUStatistics instance.
 
         :param evidence_metadata: The generating measurement's metadata
-        :type evidence_metadata: EvidenceMetadata
         :param avg: The average utilization
-        :type avg: float
         :param min: The minimum utilization
-        :type min: float
         :param max: The maximum utilization
-        :type max: float
         """
         super().__init__(self, evidence_metadata)
 
@@ -66,30 +62,26 @@ class CPUStatistics(Value):
         Serialize an CPUStatistics to a JSON object.
 
         :return: The JSON object
-        :rtype: Dict[str, Any]
         """
         return {"avg": self.avg, "min": self.min, "max": self.max}
 
     @staticmethod
     def deserialize(
-        evidence_metadata: EvidenceMetadata, json: Dict[str, Any]
+        evidence_metadata: EvidenceMetadata, data: Dict[str, Any]
     ) -> CPUStatistics:
         """
         Deserialize an CPUStatistics from a JSON object.
 
         :param evidence_metadata: The generating measurement's metadata
-        :type evidence_metadata: EvidenceMetadata
         :param json: The JSON object
-        :type json: Dict[str, Any]
 
         :return: The deserialized instance
-        :rtype: CPUStatistics
         """
         return CPUStatistics(
             evidence_metadata,
-            avg=json["avg"],
-            min=json["min"],
-            max=json["max"],
+            avg=data["avg"],
+            min=data["min"],
+            max=data["max"],
         )
 
     def __str__(self) -> str:
@@ -106,10 +98,8 @@ class CPUStatistics(Value):
         Construct and invoke a condition for maximum CPU utilization.
 
         :param threshold: The threshold value for maximum utilization
-        :type threshold: float
 
         :return: The Condition that can be used to validate a Value.
-        :rtype: Condition
         """
         condition: Condition = Condition(
             "max_utilization_less_than",
@@ -134,10 +124,8 @@ class CPUStatistics(Value):
         Construct and invoke a condition for average CPU utilization.
 
         :param threshold: The threshold value for average utilization
-        :type threshold: float
 
         :return: The Condition that can be used to validate a Value.
-        :rtype: Condition
         """
         condition: Condition = Condition(
             "average_utilization_less_than",
@@ -170,7 +158,6 @@ class LocalProcessCPUUtilization(ProcessMeasurement):
         Initialize a new LocalProcessCPUUtilization measurement.
 
         :param identifier: A unique identifier for the measurement
-        :type identifier: str
         """
         super().__init__(self, identifier)
         if is_windows():
@@ -183,12 +170,9 @@ class LocalProcessCPUUtilization(ProcessMeasurement):
         Monitor the CPU utilization of process at `pid` until exit.
 
         :param pid: The process identifier
-        :type pid: int
         :param poll_interval: The poll interval in seconds
-        :type poll_interval: int
 
         :return: The collection of CPU usage statistics
-        :rtype: dict
         """
         stats = []
         while True:
@@ -221,10 +205,8 @@ def _get_cpu_usage(pid: int) -> float:
     Get the current CPU usage for the process with `pid`.
 
     :param pid: The identifier of the process
-    :type pid: int
 
     :return: The current CPU utilization as percentage
-    :rtype: float
     """
     try:
         stdout = subprocess.check_output(

--- a/mlte/measurement/memory/local_process_memory_consumption.py
+++ b/mlte/measurement/memory/local_process_memory_consumption.py
@@ -14,7 +14,7 @@ from mlte._private.platform import is_macos, is_windows
 from mlte.evidence.metadata import EvidenceMetadata
 from mlte.spec.condition import Condition
 from mlte.validation.result import Failure, Success
-from mlte.value.artifact import Value
+from mlte.value.base import ValueBase
 
 from ..process_measurement import ProcessMeasurement
 
@@ -23,7 +23,7 @@ from ..process_measurement import ProcessMeasurement
 # -----------------------------------------------------------------------------
 
 
-class MemoryStatistics(Value):
+class MemoryStatistics(ValueBase):
     """
     The MemoryStatistics class encapsulates data
     and functionality for tracking and updating memory
@@ -65,30 +65,26 @@ class MemoryStatistics(Value):
         Serialize an MemoryStatistics to a JSON object.
 
         :return: The JSON object
-        :rtype: Dict[str, Any]
         """
         return {"avg": self.avg, "min": self.min, "max": self.max}
 
     @staticmethod
     def deserialize(
-        evidence_metadata: EvidenceMetadata, json: Dict[str, Any]
+        evidence_metadata: EvidenceMetadata, data: Dict[str, Any]
     ) -> MemoryStatistics:
         """
         Deserialize an MemoryStatistics from a JSON object.
 
         :param evidence_metadata: The generating measurement's metadata
-        :type evidence_metadata: EvidenceMetadata
         :param json: The JSON object
-        :type json: Dict[str, Any]
 
         :return: The deserialized instance
-        :rtype: MemoryStatistics
         """
         return MemoryStatistics(
             evidence_metadata,
-            avg=json["avg"],
-            min=json["min"],
-            max=json["max"],
+            avg=data["avg"],
+            min=data["min"],
+            max=data["max"],
         )
 
     def __str__(self) -> str:

--- a/mlte/value/types/integer.py
+++ b/mlte/value/types/integer.py
@@ -39,7 +39,6 @@ class Integer(Value):
         Convert an integer value artifact to its corresponding model.
         :return: The artifact model
         """
-        print("integer.to_model()")
         a = ArtifactModel(
             header=self.build_artifact_header(),
             body=ValueModel(
@@ -50,8 +49,6 @@ class Integer(Value):
                 ),
             ),
         )
-        print("return")
-        print(a)
         return a
 
     @classmethod

--- a/test/measurement/memory/test_local_process_memory_consumption.py
+++ b/test/measurement/memory/test_local_process_memory_consumption.py
@@ -135,7 +135,7 @@ def test_result_save_load(
     stats = MemoryStatistics(m, 50, 10, 800)
     stats.save_with(ctx, store)
 
-    r: MemoryStatistics = MemoryStatistics.load_with("id.value", context=ctx, stpre=store)  # type: ignore
+    r: MemoryStatistics = MemoryStatistics.load_with("id.value", context=ctx, store=store)  # type: ignore
     assert r.avg == stats.avg
     assert r.min == stats.min
     assert r.max == stats.max

--- a/test/schema/test_spec_schema.py
+++ b/test/schema/test_spec_schema.py
@@ -4,21 +4,19 @@ test/schema/test_spec_schema.py
 Unit tests for Spec schema.
 """
 
-import pytest
 
 from mlte._private.schema import validate_spec_schema
-from mlte.api import read_spec
 from mlte.property.costs import StorageCost
 from mlte.spec.spec import Spec
 from mlte.value.types.integer import Integer
 
+from ..fixture.store import store_with_context  # noqa
 
-@pytest.mark.skip("Disabled for artifact protocol development.")
-def test_instance_with_content(tmp_path):
+
+def test_instance_with_content():
     spec = Spec(
         properties={StorageCost("rationale"): {"test": Integer.less_than(3)}}
     )
-    spec.save()
 
-    doc = read_spec(f"local://{tmp_path}", "model", "0.0.1")
-    validate_spec_schema(doc)
+    doc = spec.to_model().to_json()
+    validate_spec_schema(doc["body"])

--- a/test/schema/test_validatedspec_schema.py
+++ b/test/schema/test_validatedspec_schema.py
@@ -4,10 +4,8 @@ test/schema/test_validatedspec_schema.py
 Unit tests for ValidatedSpec schema.
 """
 
-import pytest
 
 from mlte._private.schema import validate_validatedspec_schema
-from mlte.api import read_validatedspec
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.property.costs import StorageCost
 from mlte.spec.spec import Spec
@@ -15,21 +13,19 @@ from mlte.validation.spec_validator import SpecValidator
 from mlte.value.types.integer import Integer
 
 
-@pytest.mark.skip("Disabled for artifact protocol development.")
-def test_schema(tmp_path):
+def test_schema():
     spec = Spec(
         properties={StorageCost("rationale"): {"test": Integer.less_than(3)}}
     )
     specValidator = SpecValidator(spec)
     i = Integer(
         EvidenceMetadata(
-            measurement_type="typename", identifier=Identifier(name="id")
+            measurement_type="typename", identifier=Identifier(name="test")
         ),
         1,
     )
     specValidator.add_value(i)
     validatedSpec = specValidator.validate()
-    validatedSpec.save()
 
-    doc = read_validatedspec(f"local://{tmp_path}", "model", "0.0.1")
-    validate_validatedspec_schema(doc)
+    doc = validatedSpec.to_model().to_json()
+    validate_validatedspec_schema(doc["body"])

--- a/test/schema/test_value_schema.py
+++ b/test/schema/test_value_schema.py
@@ -4,53 +4,44 @@ test/schema/test_value_schema.py
 Unit tests for Value schema.
 """
 
-import pytest
-
 from mlte._private.schema import validate_value_schema
-from mlte.api import read_value
 from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.value.types.integer import Integer
 from mlte.value.types.opaque import Opaque
 from mlte.value.types.real import Real
 
 
-@pytest.mark.skip("Disabled for artifact protocol development.")
-def test_real(tmp_path):
+def test_real():
     r = Real(
         EvidenceMetadata(
             measurement_type="typename", identifier=Identifier(name="id")
         ),
         3.14,
     )
-    r.save()
 
-    d = read_value(f"local://{tmp_path}", "model", "0.0.1", "id")
-    validate_value_schema(d)
+    doc = r.to_model().to_json()
+    validate_value_schema(doc["body"])
 
 
-@pytest.mark.skip("Disabled for artifact protocol development.")
-def test_integer(tmp_path):
+def test_integer():
     r = Integer(
         EvidenceMetadata(
             measurement_type="typename", identifier=Identifier(name="id")
         ),
         3,
     )
-    r.save()
 
-    d = read_value(f"local://{tmp_path}", "model", "0.0.1", "id")
-    validate_value_schema(d)
+    doc = r.to_model().to_json()
+    validate_value_schema(doc["body"])
 
 
-@pytest.mark.skip("Disabled for artifact protocol development.")
-def test_opaque(tmp_path):
+def test_opaque():
     r = Opaque(
         EvidenceMetadata(
             measurement_type="typename", identifier=Identifier(name="id")
         ),
         {"foo": "bar"},
     )
-    r.save()
 
-    d = read_value(f"local://{tmp_path}", "model", "0.0.1", "id")
-    validate_value_schema(d)
+    doc = r.to_model().to_json()
+    validate_value_schema(doc["body"])


### PR DESCRIPTION
Mostly addresses #233, but also made some other fixes:

- Addresses #233 by making CPUStatistics and MemoryStatistics derive from ValueBase,  as well as fixed and re-enabled unit tests for these value types.
- Fixed and re-enabled schema unit tests for Spec, ValidatedSpec and Value schemas.
- Fixed demo, ensuring evidence and report notebooks work properly with new version of objects (except for report generation), and fixed bug in ConfusionMatrix which was not properly serializing a numpy array.