### PR TITLE
Feature/simpler properties

### DIFF
--- a/mlte/property/base.py
+++ b/mlte/property/base.py
@@ -1,5 +1,5 @@
 """
-mlte/property/property.py
+mlte/property/base.py
 
 The superclass for all model properties.
 """
@@ -27,7 +27,7 @@ class Property(metaclass=abc.ABCMeta):
         """
         Initialize a Property instance.
 
-        :param instance: The derived Property we are creating from.
+        :param instance: The derived Property we are constructing from.
         :param description: The description of the property
         :param rationale: The rationale for using the property
         """

--- a/mlte/property/costs/storage_cost.py
+++ b/mlte/property/costs/storage_cost.py
@@ -4,7 +4,6 @@ mlte/property/costs/storage_cost.py
 StorageCost property definition.
 """
 
-from mlte._private.text import cleantext
 from mlte.property.property import Property
 
 
@@ -16,15 +15,12 @@ class StorageCost(Property):
     def __init__(self, rationale: str):
         """Initialize a StorageCost instance."""
         super().__init__(
-            self.__class__.__name__,
-            cleantext(
-                """
+            instance=self,
+            description="""
                 The StorageCost property assesses the storage requirements of a
                 model. These requirements may be expressed in a variety of ways,
                 including the physical size of the model when it is persisted
                 to stable storage, or the number of parameters it contains.
-                """
-            ),
-            rationale,
-            __name__,
+                """,
+            rationale=rationale,
         )

--- a/mlte/property/costs/storage_cost.py
+++ b/mlte/property/costs/storage_cost.py
@@ -4,7 +4,7 @@ mlte/property/costs/storage_cost.py
 StorageCost property definition.
 """
 
-from mlte.property.property import Property
+from mlte.property.base import Property
 
 
 class StorageCost(Property):

--- a/mlte/property/costs/training_compute_cost.py
+++ b/mlte/property/costs/training_compute_cost.py
@@ -4,7 +4,6 @@ mlte/property/costs/training_compute_cost.py
 TrainingComputeCost property definition.
 """
 
-from mlte._private.text import cleantext
 from mlte.property.property import Property
 
 
@@ -19,17 +18,14 @@ class TrainingComputeCost(Property):
         Initialize a TrainingComputeCost instance.
         """
         super().__init__(
-            self.__class__.__name__,
-            cleantext(
-                """
+            instance=self,
+            description="""
                 The TrainingComputeCost property assesses the
                 computational requirements of model training.
                 This might be measured in terms of CPU utilization
                 for training processes that run locally, or the cost
                 of compute resources required for training processes
                 that run on on-demand cloud infrastructure.
-                """
-            ),
-            rationale,
-            __name__,
+                """,
+            rationale=rationale,
         )

--- a/mlte/property/costs/training_compute_cost.py
+++ b/mlte/property/costs/training_compute_cost.py
@@ -4,7 +4,7 @@ mlte/property/costs/training_compute_cost.py
 TrainingComputeCost property definition.
 """
 
-from mlte.property.property import Property
+from mlte.property.base import Property
 
 
 class TrainingComputeCost(Property):

--- a/mlte/property/costs/training_memory_cost.py
+++ b/mlte/property/costs/training_memory_cost.py
@@ -4,7 +4,7 @@ mlte/property/costs/training_memory_cost.py
 TrainingMemoryCost property definition.
 """
 
-from mlte.property.property import Property
+from mlte.property.base import Property
 
 
 class TrainingMemoryCost(Property):

--- a/mlte/property/costs/training_memory_cost.py
+++ b/mlte/property/costs/training_memory_cost.py
@@ -4,7 +4,6 @@ mlte/property/costs/training_memory_cost.py
 TrainingMemoryCost property definition.
 """
 
-from mlte._private.text import cleantext
 from mlte.property.property import Property
 
 
@@ -19,17 +18,14 @@ class TrainingMemoryCost(Property):
         Initialize a TrainingMemoryCost instance.
         """
         super().__init__(
-            self.__class__.__name__,
-            cleantext(
-                """
+            instance=self,
+            description="""
                 The TrainingMemoryCost property assesses the
                 memory requirements of model training. This might
                 be measured by the memory requirements of training
                 processes that run locally, or the cost of memory
                 resources required for training processes that run
                 on on-demand cloud infrastructure.
-                """
-            ),
-            rationale,
-            __name__,
+                """,
+            rationale=rationale,
         )

--- a/mlte/property/functionality/task_efficacy.py
+++ b/mlte/property/functionality/task_efficacy.py
@@ -4,7 +4,6 @@ mlte/property/functionality/task_efficacy.py
 TaskEfficacy property definition.
 """
 
-from mlte._private.text import cleantext
 from mlte.property.property import Property
 
 
@@ -17,16 +16,13 @@ class TaskEfficacy(Property):
     def __init__(self, rationale: str):
         """Initialize a TaskEfficacy instance."""
         super().__init__(
-            self.__class__.__name__,
-            cleantext(
-                """
+            instance=self,
+            description="""
                 The TaskEfficacy property assesses a model's ability
                 to correctly perform instances of its task. The means
                 of measurement for this property will vary by both
                 domain and task. Examples include accuracy, error rate,
                 and average precision, but many others are possible.
-                """
-            ),
-            rationale,
-            __name__,
+                """,
+            rationale=rationale,
         )

--- a/mlte/property/functionality/task_efficacy.py
+++ b/mlte/property/functionality/task_efficacy.py
@@ -4,7 +4,7 @@ mlte/property/functionality/task_efficacy.py
 TaskEfficacy property definition.
 """
 
-from mlte.property.property import Property
+from mlte.property.base import Property
 
 
 class TaskEfficacy(Property):

--- a/mlte/property/property.py
+++ b/mlte/property/property.py
@@ -11,6 +11,7 @@ import importlib
 from typing import Type
 
 import mlte._private.meta as meta
+from mlte._private.text import cleantext
 from mlte.spec.model import PropertyModel
 
 
@@ -22,26 +23,24 @@ class Property(metaclass=abc.ABCMeta):
         """Define the interface for all concrete properties."""
         return meta.has_callables(subclass, "__init__")
 
-    def __init__(
-        self, name: str, description: str, rationale: str, module: str
-    ):
+    def __init__(self, instance: Property, description: str, rationale: str):
         """
         Initialize a Property instance.
 
-        :param name: The name of the property
+        :param instance: The derived Property we are creating from.
         :param description: The description of the property
         :param rationale: The rationale for using the property
         """
-        self.name: str = name
+        self.name: str = instance.__class__.__name__
         """The name of the property."""
 
-        self.description: str = description
+        self.description: str = cleantext(description)
         """The description of the property."""
 
         self.rationale: str = rationale
         """The rationale for using the property."""
 
-        self.module: str = module
+        self.module: str = instance.__module__
         """The name of the module the property is defined in."""
 
     def to_model(self) -> PropertyModel:

--- a/mlte/spec/spec.py
+++ b/mlte/spec/spec.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Union
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactModel
 from mlte.artifact.type import ArtifactType
-from mlte.property.property import Property
+from mlte.property.base import Property
 from mlte.spec.condition import Condition
 from mlte.spec.model import PropertyModel, SpecModel
 

--- a/mlte/validation/validated_spec.py
+++ b/mlte/validation/validated_spec.py
@@ -12,7 +12,7 @@ from typing import Dict
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactModel
 from mlte.artifact.type import ArtifactType
-from mlte.property.property import Property
+from mlte.property.base import Property
 from mlte.spec.condition import Condition
 from mlte.spec.model import SpecModel
 from mlte.spec.spec import Spec

--- a/test/spec/extended_property.py
+++ b/test/spec/extended_property.py
@@ -4,7 +4,6 @@ test/spec/test_model.py
 ExtendedProperty definition, for testing purposes.
 """
 
-from mlte._private.text import cleantext
 from mlte.property.property import Property
 
 
@@ -16,12 +15,9 @@ class ExtendedProperty(Property):
     def __init__(self, rationale: str):
         """Initialize a ExtendedProperty instance."""
         super().__init__(
-            self.__class__.__name__,
-            cleantext(
-                """
+            instance=self,
+            description="""
                 The ExtendedProperty property is just for testing purposes.
-                """
-            ),
-            rationale,
-            __name__,
+                """,
+            rationale=rationale,
         )

--- a/test/spec/extended_property.py
+++ b/test/spec/extended_property.py
@@ -1,5 +1,5 @@
 """
-test/spec/test_model.py
+test/spec/extended_property.py
 
 ExtendedProperty definition, for testing purposes.
 """

--- a/test/spec/extended_property.py
+++ b/test/spec/extended_property.py
@@ -4,7 +4,7 @@ test/spec/test_model.py
 ExtendedProperty definition, for testing purposes.
 """
 
-from mlte.property.property import Property
+from mlte.property.base import Property
 
 
 class ExtendedProperty(Property):


### PR DESCRIPTION
 - Addresses #265 
 - Slight refactoring of base Property class to make it easier to create new Properties. Now, instead of people having to manually pass self.__class__name and __name__ as parameters to the base Property constructor, just an instance of the derived property is passed (along with the description and rationale), and the base Property constructor obtains those two items. This makes extending for new Properties much more user friendly.