### PR TITLE
Refactor Enum Serialization

### DIFF
--- a/mlte/artifact/model.py
+++ b/mlte/artifact/model.py
@@ -29,6 +29,9 @@ class ArtifactHeaderModel(BaseModel):
     timestamp: Optional[int] = -1
     """The timestamp of creation of this artifact, as Unix time."""
 
+    class Config:
+        use_enum_values = True
+
 
 class ArtifactModel(BaseModel):
     """The base model for all MLTE artifacts."""

--- a/mlte/artifact/type.py
+++ b/mlte/artifact/type.py
@@ -8,23 +8,23 @@ implementation because it allows us to avoid a circular dependency amongst
 the artifact base model, individual artifact models, and the type enum.
 """
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class ArtifactType(str, Enum):
     """Enumerates all supported artifact types."""
 
-    NEGOTIATION_CARD = auto()
+    NEGOTIATION_CARD = "negotiation_card"
     """The negotiation card artifact type."""
 
-    VALUE = auto()
+    VALUE = "value"
     """The value card artifact type."""
 
-    SPEC = auto()
+    SPEC = "spec"
     """The specification artifact type."""
 
-    VALIDATED_SPEC = auto()
+    VALIDATED_SPEC = "validated_spec"
     """The validated specification artifact type."""
 
-    REPORT = auto()
+    REPORT = "report"
     """The report artifact type."""

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/negotiation/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/negotiation/v0.0.1/schema.json
@@ -645,7 +645,7 @@
   "description": "The model implementation for the NegotiationCard artifact.",
   "properties": {
     "artifact_type": {
-      "const": "1",
+      "const": "negotiation_card",
       "title": "Artifact Type"
     },
     "system": {

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
@@ -650,7 +650,7 @@
   "description": "The model implementation for the MLTE report artifact.",
   "properties": {
     "artifact_type": {
-      "const": "5",
+      "const": "report",
       "title": "Artifact Type"
     },
     "summary": {

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/spec/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/spec/v0.0.1/schema.json
@@ -80,7 +80,7 @@
   "description": "The model implementation for the Spec artifact.",
   "properties": {
     "artifact_type": {
-      "const": "3",
+      "const": "spec",
       "title": "Artifact Type"
     },
     "properties": {

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/validated/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/validated/v0.0.1/schema.json
@@ -162,7 +162,7 @@
   "description": "The model implementation for the ValidatedSpec artifact.",
   "properties": {
     "artifact_type": {
-      "const": "4",
+      "const": "validated_spec",
       "title": "Artifact Type"
     },
     "spec_identifier": {

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
@@ -48,7 +48,7 @@
       "description": "The model implementation for MLTE image values.",
       "properties": {
         "value_type": {
-          "const": "4",
+          "const": "image",
           "title": "Value Type"
         },
         "data": {
@@ -67,7 +67,7 @@
       "description": "The model implementation for MLTE integer values.",
       "properties": {
         "value_type": {
-          "const": "1",
+          "const": "integer",
           "title": "Value Type"
         },
         "integer": {
@@ -86,7 +86,7 @@
       "description": "The model implementation for MLTE opaque values.",
       "properties": {
         "value_type": {
-          "const": "3",
+          "const": "opaque",
           "title": "Value Type"
         },
         "data": {
@@ -105,7 +105,7 @@
       "description": "The model implementation for MLTE real values.",
       "properties": {
         "value_type": {
-          "const": "2",
+          "const": "real",
           "title": "Value Type"
         },
         "real": {
@@ -124,7 +124,7 @@
   "description": "The model implementation for MLTE values.",
   "properties": {
     "artifact_type": {
-      "const": "2",
+      "const": "value",
       "title": "Artifact Type"
     },
     "metadata": {
@@ -133,10 +133,10 @@
     "value": {
       "discriminator": {
         "mapping": {
-          "1": "#/$defs/IntegerValueModel",
-          "2": "#/$defs/RealValueModel",
-          "3": "#/$defs/OpaqueValueModel",
-          "4": "#/$defs/ImageValueModel"
+          "image": "#/$defs/ImageValueModel",
+          "integer": "#/$defs/IntegerValueModel",
+          "opaque": "#/$defs/OpaqueValueModel",
+          "real": "#/$defs/RealValueModel"
         },
         "propertyName": "value_type"
       },

--- a/mlte/schema/artifact/negotiation/v0.0.1/schema.json
+++ b/mlte/schema/artifact/negotiation/v0.0.1/schema.json
@@ -645,7 +645,7 @@
   "description": "The model implementation for the NegotiationCard artifact.",
   "properties": {
     "artifact_type": {
-      "const": "1",
+      "const": "negotiation_card",
       "title": "Artifact Type"
     },
     "system": {

--- a/mlte/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/schema/artifact/report/v0.0.1/schema.json
@@ -650,7 +650,7 @@
   "description": "The model implementation for the MLTE report artifact.",
   "properties": {
     "artifact_type": {
-      "const": "5",
+      "const": "report",
       "title": "Artifact Type"
     },
     "summary": {

--- a/mlte/schema/artifact/spec/v0.0.1/schema.json
+++ b/mlte/schema/artifact/spec/v0.0.1/schema.json
@@ -80,7 +80,7 @@
   "description": "The model implementation for the Spec artifact.",
   "properties": {
     "artifact_type": {
-      "const": "3",
+      "const": "spec",
       "title": "Artifact Type"
     },
     "properties": {

--- a/mlte/schema/artifact/validated/v0.0.1/schema.json
+++ b/mlte/schema/artifact/validated/v0.0.1/schema.json
@@ -162,7 +162,7 @@
   "description": "The model implementation for the ValidatedSpec artifact.",
   "properties": {
     "artifact_type": {
-      "const": "4",
+      "const": "validated_spec",
       "title": "Artifact Type"
     },
     "spec_identifier": {

--- a/mlte/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/schema/artifact/value/v0.0.1/schema.json
@@ -48,7 +48,7 @@
       "description": "The model implementation for MLTE image values.",
       "properties": {
         "value_type": {
-          "const": "4",
+          "const": "image",
           "title": "Value Type"
         },
         "data": {
@@ -67,7 +67,7 @@
       "description": "The model implementation for MLTE integer values.",
       "properties": {
         "value_type": {
-          "const": "1",
+          "const": "integer",
           "title": "Value Type"
         },
         "integer": {
@@ -86,7 +86,7 @@
       "description": "The model implementation for MLTE opaque values.",
       "properties": {
         "value_type": {
-          "const": "3",
+          "const": "opaque",
           "title": "Value Type"
         },
         "data": {
@@ -105,7 +105,7 @@
       "description": "The model implementation for MLTE real values.",
       "properties": {
         "value_type": {
-          "const": "2",
+          "const": "real",
           "title": "Value Type"
         },
         "real": {
@@ -124,7 +124,7 @@
   "description": "The model implementation for MLTE values.",
   "properties": {
     "artifact_type": {
-      "const": "2",
+      "const": "value",
       "title": "Artifact Type"
     },
     "metadata": {
@@ -133,10 +133,10 @@
     "value": {
       "discriminator": {
         "mapping": {
-          "1": "#/$defs/IntegerValueModel",
-          "2": "#/$defs/RealValueModel",
-          "3": "#/$defs/OpaqueValueModel",
-          "4": "#/$defs/ImageValueModel"
+          "image": "#/$defs/ImageValueModel",
+          "integer": "#/$defs/IntegerValueModel",
+          "opaque": "#/$defs/OpaqueValueModel",
+          "real": "#/$defs/RealValueModel"
         },
         "propertyName": "value_type"
       },

--- a/mlte/value/model.py
+++ b/mlte/value/model.py
@@ -6,7 +6,7 @@ Model implementation for MLTE value types.
 
 from __future__ import annotations
 
-from enum import Enum, auto
+from enum import Enum
 from typing import Any, Dict, Literal, Union
 
 from pydantic import Field
@@ -19,16 +19,16 @@ from mlte.model import BaseModel
 class ValueType(str, Enum):
     """An enumeration over supported value types."""
 
-    INTEGER = auto()
+    INTEGER = "integer"
     """An integral type."""
 
-    REAL = auto()
+    REAL = "real"
     """A real type."""
 
-    OPAQUE = auto()
+    OPAQUE = "opaque"
     """An opaque type."""
 
-    IMAGE = auto()
+    IMAGE = "image"
     """An image media type."""
 
 

--- a/mlte/value/model.py
+++ b/mlte/value/model.py
@@ -59,6 +59,9 @@ class IntegerValueModel(BaseModel):
     integer: int
     """The encapsulated value."""
 
+    class Config:
+        use_enum_values = True
+
 
 class RealValueModel(BaseModel):
     """The model implementation for MLTE real values."""
@@ -68,6 +71,9 @@ class RealValueModel(BaseModel):
 
     real: float
     """The encapsulated value."""
+
+    class Config:
+        use_enum_values = True
 
 
 class OpaqueValueModel(BaseModel):
@@ -79,6 +85,9 @@ class OpaqueValueModel(BaseModel):
     data: Dict[str, Any]
     """Encapsulated, opaque data."""
 
+    class Config:
+        use_enum_values = True
+
 
 class ImageValueModel(BaseModel):
     """The model implementation for MLTE image values."""
@@ -88,6 +97,9 @@ class ImageValueModel(BaseModel):
 
     data: str
     """The image data as base64-encoded string."""
+
+    class Config:
+        use_enum_values = True
 
 
 ValueModel.model_rebuild()

--- a/testbed/main.py
+++ b/testbed/main.py
@@ -11,10 +11,8 @@ from resolver import package_root
 
 sys.path.append(package_root())
 
-import mlte
-import mlte.api as api
-from mlte.measurement.storage import LocalObjectSize
-from mlte.value.types.integer import Integer
+from mlte.negotiation.artifact import NegotiationCard
+from mlte.session import set_context, set_store
 
 # Script exit codes
 EXIT_SUCCESS = 0
@@ -22,19 +20,14 @@ EXIT_FAILURE = 1
 
 
 def main() -> int:
-    here = os.path.abspath(os.getcwd())
-    here = os.path.join(here, "deleteme")
-    uri = f"local://{here}"
+    store_path = os.path.join(os.getcwd(), "store")
+    os.makedirs(store_path, exist_ok=True)
 
-    mlte.set_model("FakeModel", "0.0.1")
-    mlte.set_artifact_store_uri(uri)
+    set_context("ns", "IrisClassifier", "0.0.1")
+    set_store(f"local://{store_path}")
 
-    m = LocalObjectSize("file size")
-    r: Integer = m.evaluate(os.path.abspath(__file__))
-    r.save()
-
-    result = api.read_value(uri, "FakeModel", "0.0.1", "file size")
-    print(result)
+    card = NegotiationCard()
+    card.save(force=True, parents=True)
 
     return EXIT_SUCCESS
 

--- a/testbed/resolver.py
+++ b/testbed/resolver.py
@@ -12,4 +12,4 @@ def package_root() -> str:
     path = os.path.dirname(os.path.abspath(__file__))
     while os.path.basename(os.path.abspath(path)) != "testbed":
         path = os.path.join(path, "..")
-    return os.path.abspath(os.path.join(path, "..", "src/"))
+    return os.path.abspath(os.path.join(path, "..", "mlte/"))


### PR DESCRIPTION
This PR refactors enum serialization for MLTE artifacts.

Previously, I had used `auto` to automatically generate the value of the `enum`. However, without the `StrEnum` type, this feature is only capable of generating integers for the `enum` value, making it difficult to recover the `enum` from the serialized representation.

To fix this, I just removed use of `auto` and inserted explicit strings manually for the enumerations.