### PR TITLE
Feature/condition updates

### DIFF
--- a/demo/simple/confusion_matrix.py
+++ b/demo/simple/confusion_matrix.py
@@ -58,9 +58,7 @@ class ConfusionMatrix(ValueBase):
 
     @classmethod
     def misclassification_count_less_than(cls, threshold: int) -> Condition:
-        condition: Condition = Condition(
-            "misclassification_count_less_than",
-            [threshold],
+        condition: Condition = Condition.build_condition(
             lambda cm: Success(
                 f"Misclass count {cm.misclassifications} less than threshold {threshold}"
             )

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/spec/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/spec/v0.0.1/schema.json
@@ -16,11 +16,16 @@
         "callback": {
           "title": "Callback",
           "type": "string"
+        },
+        "value_class": {
+          "title": "Value Class",
+          "type": "string"
         }
       },
       "required": [
         "name",
-        "callback"
+        "callback",
+        "value_class"
       ],
       "title": "ConditionModel",
       "type": "object"

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/validated/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/validated/v0.0.1/schema.json
@@ -16,11 +16,16 @@
         "callback": {
           "title": "Callback",
           "type": "string"
+        },
+        "value_class": {
+          "title": "Value Class",
+          "type": "string"
         }
       },
       "required": [
         "name",
-        "callback"
+        "callback",
+        "value_class"
       ],
       "title": "ConditionModel",
       "type": "object"

--- a/mlte/measurement/cpu/local_process_cpu_utilization.py
+++ b/mlte/measurement/cpu/local_process_cpu_utilization.py
@@ -101,9 +101,7 @@ class CPUStatistics(ValueBase):
 
         :return: The Condition that can be used to validate a Value.
         """
-        condition: Condition = Condition(
-            "max_utilization_less_than",
-            [threshold],
+        condition: Condition = Condition.build_condition(
             lambda stats: Success(
                 f"Maximum utilization {stats.max:.2f} "
                 f"below threshold {threshold:.2f}"
@@ -127,9 +125,7 @@ class CPUStatistics(ValueBase):
 
         :return: The Condition that can be used to validate a Value.
         """
-        condition: Condition = Condition(
-            "average_utilization_less_than",
-            [threshold],
+        condition: Condition = Condition.build_condition(
             lambda stats: Success(
                 f"Average utilization {stats.max:.2f} "
                 f"below threshold {threshold:.2f}"

--- a/mlte/measurement/memory/local_process_memory_consumption.py
+++ b/mlte/measurement/memory/local_process_memory_consumption.py
@@ -107,9 +107,7 @@ class MemoryStatistics(ValueBase):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "max_consumption_less_than",
-            [threshold],
+        condition: Condition = Condition.build_condition(
             lambda stats: Success(
                 f"Maximum consumption {stats.max} "
                 f"below threshold {threshold}"
@@ -135,9 +133,7 @@ class MemoryStatistics(ValueBase):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "average_consumption_less_than",
-            [threshold],
+        condition: Condition = Condition.build_condition(
             lambda stats: Success(
                 f"Average consumption {stats.avg} "
                 f"below threshold {threshold}"

--- a/mlte/schema/artifact/spec/v0.0.1/schema.json
+++ b/mlte/schema/artifact/spec/v0.0.1/schema.json
@@ -16,11 +16,16 @@
         "callback": {
           "title": "Callback",
           "type": "string"
+        },
+        "value_class": {
+          "title": "Value Class",
+          "type": "string"
         }
       },
       "required": [
         "name",
-        "callback"
+        "callback",
+        "value_class"
       ],
       "title": "ConditionModel",
       "type": "object"

--- a/mlte/schema/artifact/validated/v0.0.1/schema.json
+++ b/mlte/schema/artifact/validated/v0.0.1/schema.json
@@ -16,11 +16,16 @@
         "callback": {
           "title": "Callback",
           "type": "string"
+        },
+        "value_class": {
+          "title": "Value Class",
+          "type": "string"
         }
       },
       "required": [
         "name",
-        "callback"
+        "callback",
+        "value_class"
       ],
       "title": "ConditionModel",
       "type": "object"

--- a/mlte/spec/condition.py
+++ b/mlte/spec/condition.py
@@ -7,8 +7,9 @@ The interface for measurement validation.
 from __future__ import annotations
 
 import base64
+import inspect
 import typing
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Type
 
 import dill
 
@@ -28,12 +29,15 @@ class Condition:
         name: str,
         arguments: List[Any],
         callback: Callable[[Value], Result],
+        value_class: Type[Value] = Value,
     ):
         """
         Initialize a Condition instance.
 
         :param name: The name of the name method, for documenting purposes.
-        :param callback: The callable that implements validation
+        :param arguments: The list of arguments passed to the callable.
+        :param callback: The callable that implements validation.
+        :param value_class: The full module + class name of the Value that generated this condition.
         """
 
         self.name: str = name
@@ -44,6 +48,8 @@ class Condition:
 
         self.callback: Callable[[Value], Result] = callback
         """The callback that implements validation."""
+
+        self.value_class: str = Condition.value_class_to_str(value_class)
 
     def __call__(self, value: Value) -> Result:
         """
@@ -65,7 +71,47 @@ class Condition:
             name=self.name,
             arguments=self.arguments,
             callback=Condition.encode_callback(self.callback),
+            value_class=self.value_class,
         )
+
+    @staticmethod
+    def build_condition(test: Callable[[Value], Result]) -> Condition:
+        # Get info about caller function using inspection.
+        curr_frame = inspect.currentframe()
+        if curr_frame is None:
+            raise Exception("Unexpected error reading validation method data.")
+        caller_function = curr_frame.f_back
+        if caller_function is None:
+            raise Exception("Unexpected error reading validation method data.")
+        validation_name = caller_function.f_code.co_name
+        arguments = caller_function.f_locals
+        cls = arguments["cls"]
+
+        # Validation args are all arguments except for the value class type.
+        validation_args = []
+        for arg_key, arg_value in arguments.items():
+            if arg_key != "cls":
+                validation_args.append(arg_value)
+
+        condition: Condition = Condition(
+            validation_name, validation_args, test, cls
+        )
+        return condition
+
+    @staticmethod
+    def value_class_to_str(value_class: Type[Value]) -> str:
+        """Returns a full module.class name string for the given type."""
+        return f"{value_class.__module__}.{value_class.__name__}"
+
+    @staticmethod
+    @typing.no_type_check
+    def str_to_value_class(value_class: str) -> Type[Value]:
+        import sys
+
+        parts = value_class.rsplit(".", 1)
+        module_name = parts[0]
+        class_name = parts[1]
+        return getattr(sys.modules[module_name], class_name)
 
     @staticmethod
     def encode_callback(callback: Callable[[Value], Result]) -> str:
@@ -85,12 +131,13 @@ class Condition:
             model.name,
             model.arguments,
             dill.loads(base64.b64decode(str(model.callback).encode("utf-8"))),
+            Condition.str_to_value_class(model.value_class),
         )
         return condition
 
     def __str__(self) -> str:
         """Return a string representation of Condition."""
-        return f"{self.name}"
+        return f"{self.name} ({self.arguments}): {self.value_class}"
 
     # -------------------------------------------------------------------------
     # Equality Testing
@@ -98,7 +145,6 @@ class Condition:
 
     def __eq__(self, other: object) -> bool:
         """Compare Condition instances for equality."""
-        # TODO: is just names enough? Should we compare args and callback?
         if not isinstance(other, Condition):
             return False
         reference: Condition = other
@@ -107,6 +153,7 @@ class Condition:
             and Condition.encode_callback(self.callback)
             == Condition.encode_callback(other.callback)
             and self.arguments == other.arguments
+            and self.value_class == other.value_class
         )
 
     def __neq__(self, other: Condition) -> bool:

--- a/mlte/spec/condition.py
+++ b/mlte/spec/condition.py
@@ -136,7 +136,7 @@ class Condition:
 
     def __str__(self) -> str:
         """Return a string representation of Condition."""
-        return f"{self.name} ({self.arguments}): {self.value_class}"
+        return f"{self.name} ({self.arguments}) from {self.value_class}"
 
     # -------------------------------------------------------------------------
     # Equality Testing

--- a/mlte/spec/model.py
+++ b/mlte/spec/model.py
@@ -22,6 +22,9 @@ class ConditionModel(BaseModel):
     callback: str
     """A text-encoded, dilled-serialized version of the callback to execute when validating this condition."""
 
+    value_class: str
+    """A string indicating the full module and class name of the Value used to generate this condition."""
+
 
 class PropertyModel(BaseModel):
     """A description of a property."""

--- a/mlte/value/types/image.py
+++ b/mlte/value/types/image.py
@@ -91,9 +91,7 @@ class Image(Value):
         :param reason: The reason for ignoring the image
         :return: The Condition that can be used to validate a Value.
         """
-        condition: Condition = Condition(
-            "Ignore",
-            [reason],
+        condition: Condition = Condition.build_condition(
             lambda _: Ignore(reason),
         )
         return condition

--- a/mlte/value/types/integer.py
+++ b/mlte/value/types/integer.py
@@ -94,16 +94,14 @@ class Integer(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "less_than",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda integer: Success(
                 f"Integer magnitude {integer.value} less than threshold {value}"
             )
             if integer.value < value
             else Failure(
                 f"Integer magnitude {integer.value} exceeds threshold {value}"
-            ),
+            )
         )
         return condition
 
@@ -118,9 +116,7 @@ class Integer(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "less_or_equal_to",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda integer: Success(
                 f"Integer magnitude {integer.value} "
                 f"less than or equal to threshold {value}"

--- a/mlte/value/types/real.py
+++ b/mlte/value/types/real.py
@@ -92,9 +92,7 @@ class Real(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "less_than",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda real: Success(
                 f"Real magnitude {real.value} less than threshold {value}"
             )
@@ -116,9 +114,7 @@ class Real(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "less_or_equal_to",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda real: Success(
                 f"Real magnitude {real.value} "
                 f"less than or equal to threshold {value}"
@@ -141,9 +137,7 @@ class Real(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "greater_than",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda real: Success(
                 f"Real magnitude {real.value} greater than threshold {value}"
             )
@@ -165,16 +159,12 @@ class Real(Value):
         :return: The Condition that can be used to validate a Value.
         :rtype: Condition
         """
-        condition: Condition = Condition(
-            "greater_or_equal_to",
-            [value],
+        condition: Condition = Condition.build_condition(
             lambda real: Success(
                 f"Real magnitude {real.value} "
                 f"greater than or equal to threshold {value}"
             )
             if real.value >= value
-            else Failure(
-                f"Real magnitude {real.value} below threshold {value}"
-            ),
+            else Failure(f"Real magnitude {real.value} below threshold {value}")
         )
         return condition

--- a/test/spec/test_condition.py
+++ b/test/spec/test_condition.py
@@ -18,6 +18,7 @@ def test_condition_model() -> None:
             name="less_than",
             arguments=[3.0],
             callback="invalid^#*@&^ASD@#",
+            value_class="mlte.value.types.real.Real",
         ),
         ConditionModel(
             name="greater_than",
@@ -27,6 +28,7 @@ def test_condition_model() -> None:
                 if 3 < 4
                 else Failure("Real magnitude 2 exceeds threshold 1")
             ),
+            value_class="mlte.value.types.real.Real",
         ),
     ]
 

--- a/test/spec/test_condition.py
+++ b/test/spec/test_condition.py
@@ -6,9 +6,29 @@ Unit tests for Conditions.
 
 from __future__ import annotations
 
+from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.spec.condition import Condition
 from mlte.spec.model import ConditionModel
 from mlte.validation.result import Failure, Success
+from mlte.value.types.real import Real
+
+
+class TestValue:
+    """Test value class to test build_condition method."""
+
+    @classmethod
+    def in_between(cls, arg1: float, arg2: float) -> Condition:
+        """Checks if the value is in between the arguments."""
+        condition: Condition = Condition.build_condition(
+            lambda real: Success(
+                f"Real magnitude {real.value} between {arg1} and {arg2}"
+            )
+            if real.value > arg1 and real.value < arg2
+            else Failure(
+                f"Real magnitude {real.value} not between {arg1} and {arg2}"
+            )
+        )
+        return condition
 
 
 def test_condition_model() -> None:
@@ -36,3 +56,34 @@ def test_condition_model() -> None:
         s = object.to_json()
         d = ConditionModel.from_json(s)
         assert d == object
+
+
+def test_build_condition():
+    """Tests that the build_condition method builds the expected condition."""
+    test_value = TestValue()
+
+    condition = test_value.in_between(1, 10)
+
+    assert (
+        condition.name == "in_between"
+        and condition.arguments == [1, 10]
+        and condition.value_class == "test.spec.test_condition.TestValue"
+    )
+
+
+def test_call_condition():
+    """Check execution of condition."""
+    test_value = TestValue()
+    condition = test_value.in_between(1.0, 10.0)
+    ev = EvidenceMetadata(
+        measurement_type="measure1", identifier=Identifier(name="id")
+    )
+
+    result = condition(Real(ev, 3.0))
+    assert str(result) == "Success"
+
+    result = condition(Real(ev, 0.0))
+    assert str(result) == "Failure"
+
+    result = condition(Real(ev, 1.0))
+    assert str(result) == "Failure"

--- a/test/spec/test_condition.py
+++ b/test/spec/test_condition.py
@@ -85,5 +85,5 @@ def test_call_condition():
     result = condition(Real(ev, 0.0))
     assert str(result) == "Failure"
 
-    result = condition(Real(ev, 1.0))
+    result = condition(Real(ev, 11.0))
     assert str(result) == "Failure"

--- a/test/spec/test_condition.py
+++ b/test/spec/test_condition.py
@@ -1,0 +1,36 @@
+"""
+test/spec/test_condition.py
+
+Unit tests for Conditions.
+"""
+
+from __future__ import annotations
+
+from mlte.spec.condition import Condition
+from mlte.spec.model import ConditionModel
+from mlte.validation.result import Failure, Success
+
+
+def test_condition_model() -> None:
+    """A Condition model can be serialized and deserialized."""
+    conditions = [
+        ConditionModel(
+            name="less_than",
+            arguments=[3.0],
+            callback="invalid^#*@&^ASD@#",
+        ),
+        ConditionModel(
+            name="greater_than",
+            arguments=[1, 2],
+            callback=Condition.encode_callback(
+                lambda real: Success("Real magnitude 2 less than threshold 3")
+                if 3 < 4
+                else Failure("Real magnitude 2 exceeds threshold 1")
+            ),
+        ),
+    ]
+
+    for object in conditions:
+        s = object.to_json()
+        d = ConditionModel.from_json(s)
+        assert d == object

--- a/test/spec/test_model.py
+++ b/test/spec/test_model.py
@@ -30,6 +30,7 @@ def test_spec_body() -> None:
                             name="less_than",
                             arguments=[3.0],
                             callback="invalid^#*@&^ASD@#",
+                            value_class="mlte.value.types.real.Real",
                         )
                     },
                 )

--- a/test/validation/test_model.py
+++ b/test/validation/test_model.py
@@ -32,6 +32,7 @@ def test_validated_spec_body() -> None:
                             name="less_than",
                             arguments=[3.0],
                             callback="invalid^#*@&^ASD@#",
+                            value_class="mlte.value.types.real.Real",
                         )
                     },
                     results={


### PR DESCRIPTION
Addresses #239 and adds a few more improvements. More specifically:

- Adds a field, "value_class", to conditions, where the full name (i.e., module and class name) of the Value type from which the Condition was created is stored. This is done mostly for tracking purposes, but it also makes it much easier to figure out how something was validated (before, we were only storing method name, such as "misclassification_count_less_than", but now with the value class, we would also store where that method came from, such as "confusion_matrix.ConfusionMatrix").
- Related to the above, made a modification to make it easier to create Conditions/validation methods. Previously, when creating a Condition inside a validation method, one had to explicitly pass not only the function callback that would do the test, but the name of the condition, a list of arguments (for recording purposes only), and now, the class type of the Value generating it. This was getting too cumbersome for users that want to extend Value types and add new validation methods. There is now a build_condition() static method in Condition that should be used to create Conditions instead, that only receives the callback test function. This method uses inspection of the stack to get the validation method's name, arguments, and class of the Value type that generates the Condition, thus making it much more user friendly and less error prone by automating and hiding these details. There is a bit of a performance hit for doing this, but since generating a Spec is not something that has to be very performant, it should not matter (the performance hit is not really notorious).