### PR TITLE
Publish using MacOS

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.6
+current_version = 0.2.7
 
 [bumpversion:file:./docs/docs/index.md]
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ build/
 
 # credentials
 token.txt
+
+# docs
+docs/site

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `mlte` (pronounced "melt") is a framework and infrastructure for machine learning evaluation.
 
-![Version Badge](https://img.shields.io/badge/release-v0.2.6-e19b38)
+![Version Badge](https://img.shields.io/badge/release-v0.2.7-e19b38)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Tests](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml/badge.svg)](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml)
 [![Documentation Status](https://readthedocs.org/projects/mlte/badge/?version=latest)](https://mlte.readthedocs.io/en/latest/?badge=latest)

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -164,18 +164,26 @@ Bumping the version for a new release can be accomplished with:
 $ bumpversion patch
 ```
 
-where `patch` may be replaced with `minor` or `major` as appropriate for the release.
+where `patch` may be replaced with `minor` or `major` as appropriate for the release. You may need to use:
+
+```bash
+$ bumpversion --allow-dirty patch
+```
 
 ## Publishing
 
-We publish the `MLTE` package on <a href="https://pypi.org/" target="_blank">PyPi</a>. The current procedure we follow for publication is described below.
-
-Ensure you have properly incremented the version for the new release, as described in Versioning above.
+We publish the `MLTE` package on <a href="https://pypi.org/" target="_blank">PyPi</a>. Ensure you have properly incremented the version for the new release, as described in Versioning above.
 
 Build the static distribution for the front end; the command below assumes that you have the dependencies for front end builds installed:
 
 ```bash
 $ cd mlte/frontend/nuxt-app && npm run build
+```
+
+If publishing on MacOS, you'll need to remove the node_modules directory before building the package (they can be reinstalled afterwards using `npm install`):
+
+```bash
+$ rm -rf mlte/frontend/nuxt-app/node_modules
 ```
 
 Create the source distribution and wheel:
@@ -184,10 +192,10 @@ Create the source distribution and wheel:
 $ poetry build
 ```
 
-Publish the package to `PyPi`:
+Publish the package to `PyPi` using a PyPi API token:
 
 ```bash
-$ poetry publish --username <USERNAME> --password <PASSWORD>
+$ poetry publish --username __token__ --password <TOKEN>
 ```
 
 ### Docker Integration

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -17,7 +17,7 @@ Welcome to the `MLTE` Documentation!
 
 ## More Information
 
-- Version: 0.2.6
+- Version: 0.2.7
 - Contact Email: mlte dot team dot info at gmail dot com
 - Citation: While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use `MLTE` for academic research.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,12 @@ authors = ["MLTE Engineers"]
 packages = [
   { include = "mlte" }
 ]
+
 include = [
-  "mlte/**/*.py",
   "mlte/frontend/nuxt-app/.output/public/**/*"
+]
+exclude = [
+  "mlte/frontend/nuxt-app/**/**/*"
 ]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mlte-python"
-version = "0.2.6"
+version = "0.2.7"
 description = "An infrastructure for machine learning test and evaluation."
 authors = ["MLTE Engineers"]
 packages = [


### PR DESCRIPTION
Publish the package using MacOS; addresses issue with poetry build calling on a version of python that did not exist in the file system.
Updated the development docs to account for this issue.
New package version includes several new UI features!