### PR TITLE
Fix timestamp display

### DIFF
--- a/mlte/frontend/nuxt-app/pages/index.vue
+++ b/mlte/frontend/nuxt-app/pages/index.vue
@@ -554,14 +554,13 @@ async function updateSelectedVersion(versionName: string) {
 // TODO : Do better typing on the artifactList and artifact
 function populateArtifacts(model: string, version: string, artifactList: any) {
   artifactList.forEach((artifact: any) => {
+    artifact.header.timestamp = new Date(artifact.header.timestamp * 1000).toLocaleString("en-US");
     // Negotiation card
     if (artifact.header.type === "negotiation_card") {
       if (isValidNegotiation(artifact)) {
         negotiationCards.value.push({
           id: artifact.header.identifier,
-          timestamp: new Date(artifact.header.timestamp).toLocaleString(
-            "en-US",
-          ),
+          timestamp: artifact.header.timestamp,
           model,
           version,
         });
@@ -572,9 +571,7 @@ function populateArtifacts(model: string, version: string, artifactList: any) {
       if (isValidReport(artifact)) {
         reports.value.push({
           id: artifact.header.identifier,
-          timestamp: new Date(artifact.header.timestamp).toLocaleString(
-            "en-US",
-          ),
+          timestamp: artifact.header.timestamp,
           model,
           version,
         });
@@ -585,9 +582,7 @@ function populateArtifacts(model: string, version: string, artifactList: any) {
       if (isValidSpec(artifact)) {
         specifications.value.push({
           id: artifact.header.identifier,
-          timestamp: new Date(artifact.header.timestamp).toLocaleString(
-            "en-US",
-          ),
+          timestamp: artifact.header.timestamp,
           model,
           version,
         });
@@ -599,9 +594,7 @@ function populateArtifacts(model: string, version: string, artifactList: any) {
         validatedSpecs.value.push({
           id: artifact.header.identifier,
           specid: artifact.body.spec_identifier,
-          timestamp: new Date(artifact.header.timestamp).toLocaleString(
-            "en-US",
-          ),
+          timestamp: artifact.header.timestamp,
           model,
           version,
         });
@@ -614,9 +607,7 @@ function populateArtifacts(model: string, version: string, artifactList: any) {
           id: artifact.header.identifier.slice(0, -6),
           measurement: artifact.body.metadata.measurement_type,
           type: artifact.body.value.value_type,
-          timestamp: new Date(artifact.header.timestamp).toLocaleString(
-            "en-US",
-          ),
+          timestamp: artifact.header.timestamp,
           model,
           version,
         });


### PR DESCRIPTION
Addresses #361 

Second attempt at fixing the timestamp display in the homepage table. All timestamps are now generated in the backend so they are consistently passed to the frontend in the same way and can be displayed correctly.