### PR TITLE
Add Negotiation Card to Docs, Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,28 @@
 
 ### Getting Started
 
-`mlte` is available on [PyPI](https://pypi.org/project/mlte-python/). Install the latest version with:
+`mlte` is available on <a href="https://pypi.org/project/mlte-python/" target="_blank">PyPI</a>. Install the latest version with:
 
 ```bash
 $ pip install mlte-python
 ```
 
-Once installed, you can head to our guide on [using MLTE](https://mlte.readthedocs.io/en/latest/using_mlte/) for next steps. If you just want to know how to use the package in an existing project, check out our [MLTE Mechanics](https://mlte.readthedocs.io/en/latest/mlte_mechanics/) guide. If you're interested in reading about the project more generally, see our [documentation](https://mlte.readthedocs.io/en/latest/).
+Once installed, you can head to our guide on <a href="https://mlte.readthedocs.io/en/latest/using_mlte/" target="_blank">using MLTE</a> for next steps. If you just want to know how to use the package in an existing project, check out our <a href="https://mlte.readthedocs.io/en/latest/mlte_mechanics/" target="_blank">MLTE Mechanics</a> guide. If you're interested in reading about the project more generally, see our <a href="https://mlte.readthedocs.io/en/latest/" target="_blank">documentation</a>.
 
 ### Citing This Work
 
-If you're interested in learning more about this work, you can read our [paper](https://arxiv.org/abs/2303.01998). While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use MLTE for academic research.
+If you're interested in learning more about this work, you can read our <a href="https://ieeexplore.ieee.org/document/10173876" target="_blank">paper</a>. While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use MLTE for academic research.
 
 ```
-@article{maffey2023mlteing,
-  title={MLTEing Models: Negotiating, Evaluating, and Documenting Model and System Qualities},
-  author={Maffey, Katherine R and Dotterrer, Kyle and Niemann, Jennifer and Cruickshank, Iain
-  and Lewis, Grace A and K{\"a}stner, Christian},
-  journal={arXiv preprint arXiv:2303.01998},
-  year={2023}
+@INPROCEEDINGS{10173876,
+  author={Maffey, Katherine R. and Dotterrer, Kyle and Niemann, Jennifer and Cruickshank, Iain and Lewis, Grace A. and Kästner, Christian},
+  booktitle={2023 IEEE/ACM 45th International Conference on Software Engineering: New Ideas and Emerging Results (ICSE-NIER)}, 
+  title={MLTEing Models: Negotiating, Evaluating, and Documenting Model and System Qualities}, 
+  year={2023},
+  volume={},
+  number={},
+  pages={31-36},
+  keywords={Measurement;Machine learning;Production;Organizations;Software;Stakeholders;Software engineering;machine learning;test and evaluation;machine learning evaluation;responsible AI},
+  doi={10.1109/ICSE-NIER58687.2023.00012}
 }
 ```

--- a/docs/docs/negotiation_card.md
+++ b/docs/docs/negotiation_card.md
@@ -1,0 +1,98 @@
+# MLTE Negotiation Card
+
+## Goals of the system
+
+Goals or objectives that the model is going to help satisfy.
+
+Example: Match voice recordings that belong to the same person 
+
+## Baseline 
+
+Select a baseline for each performance metric, which means a measurement that evaluates whether or not the model will/can achieve the main goal for which it is being created. If the goal cannot be measured directly, select a reasonable proxy and justify how that will reliably predict the model’s performance in achieving its goal.
+
+Example: Human accuracy for matching voices is ~60%
+
+## ML Problem Type 
+
+Type of ML problem that the model is intended to solve.
+
+Example: Classification
+
+## ML Task 
+
+Well-defined task that model is expected to perform, or problem that the model is expected to solve.
+
+Example: Identifying which voice recordings were spoken by the same person
+
+## Usage Context
+
+Who is intended to utilize the system/model; how the results of the model are going to be used by end users or in the context of a larger system.
+
+Example: Analyzing many recordings to determine which ones include a specific person of interest
+
+## Data
+
+Details of the data that will influence development efforts; fill out all that are known.
+
+### Source
+
+Where is the data coming from?
+
+### Classification
+
+What classification is the data?
+
+### Access / Availability
+
+How will the data be accessed? What accounts are needed?
+
+### Labels / Distribution
+List out all the labels for the data, along with the percentage of data they account for (if known).
+
+### Schema
+
+Include relevant information that is known about the data; fill out all sections below for each data field. E.g., if there are four data fields, you would have four versions of the following descriptors, one for each data field.
+
+#### Field Name: 
+#### Field Description: 
+#### Field Type: 
+#### Expected Values: 
+#### Missing Values: 
+#### Special Values: 
+
+### Rights
+
+Are there particular ways in which the data can and cannot be used?
+
+### Policies 
+
+Are there policies that govern the data and its use, such as Personally Identifiable Information [PII]?
+
+## Risk of producing a false positive
+
+## Risk of producing a false negative
+
+## Other risks of producing incorrect results
+
+## Output specification
+
+Describe the output format and specification needed for the system to ingest model results.
+
+## Development compute resources
+
+Describe the amount and type of compute resources needed for training.
+
+### GPUs: 
+### CPUs: 
+### Memory: 
+### Storage: 
+
+## Production Environment
+
+### Production Requirements
+
+Describe how the model will be integrated into the system; this likely includes descriptions of model deployment, application hosting, etc.
+
+### Inference Requirements 
+
+Describe the hardware and software requirements including amount of compute resources needed for inference.

--- a/docs/docs/negotiation_card.md
+++ b/docs/docs/negotiation_card.md
@@ -1,55 +1,73 @@
 # MLTE Negotiation Card
 
-## Goals of the system
+## System Requirements
 
-Goals or objectives that the model is going to help satisfy.
+### Goals of the System
+
+Goals or objectives that the model is going to help satisfy. For each goal, there can be one or more metrics to measure that goal, and every metric has a corresponding baseline.
 
 Example: Match voice recordings that belong to the same person 
 
-## Baseline 
+#### Metric
+
+For each goal, select a performance metric that captures the system's ability to accomplish that goal.
+
+Example: Accuracy on matching voices from the same person
+
+#### Baseline 
 
 Select a baseline for each performance metric, which means a measurement that evaluates whether or not the model will/can achieve the main goal for which it is being created. If the goal cannot be measured directly, select a reasonable proxy and justify how that will reliably predict the model’s performance in achieving its goal.
 
 Example: Human accuracy for matching voices is ~60%
 
-## ML Problem Type 
+### ML Problem Type 
 
 Type of ML problem that the model is intended to solve.
 
 Example: Classification
 
-## ML Task 
+### ML Task 
 
 Well-defined task that model is expected to perform, or problem that the model is expected to solve.
 
 Example: Identifying which voice recordings were spoken by the same person
 
-## Usage Context
+### Usage Context
 
 Who is intended to utilize the system/model; how the results of the model are going to be used by end users or in the context of a larger system.
 
 Example: Analyzing many recordings to determine which ones include a specific person of interest
 
+### Risk of Producing a False Positive
+
+### Risk of Producing a False Negative
+
+### Other Risks of Producing Incorrect Results
+
 ## Data
 
 Details of the data that will influence development efforts; fill out all that are known.
 
-### Source
+### Data Description
+
+Describe the data generally.
+
+### Data Source
 
 Where is the data coming from?
 
-### Classification
+### Data Classification
 
 What classification is the data?
 
-### Access / Availability
+### Data Access / Availability
 
-How will the data be accessed? What accounts are needed?
+How will the data be accessed? Record what needs to happen to access the data, such as accounts that need to be created or methods for data transportation.
 
-### Labels / Distribution
+### Data Labels / Distribution
 List out all the labels for the data, along with the percentage of data they account for (if known).
 
-### Schema
+### Data Schema
 
 Include relevant information that is known about the data; fill out all sections below for each data field. E.g., if there are four data fields, you would have four versions of the following descriptors, one for each data field.
 
@@ -60,39 +78,44 @@ Include relevant information that is known about the data; fill out all sections
 #### Missing Values: 
 #### Special Values: 
 
-### Rights
+### Data Rights
 
 Are there particular ways in which the data can and cannot be used?
 
-### Policies 
+### Data Policies 
 
 Are there policies that govern the data and its use, such as Personally Identifiable Information [PII]?
 
-## Risk of producing a false positive
+## Model
 
-## Risk of producing a false negative
-
-## Other risks of producing incorrect results
-
-## Output specification
-
-Describe the output format and specification needed for the system to ingest model results.
-
-## Development compute resources
+### Development Compute Resources
 
 Describe the amount and type of compute resources needed for training.
 
-### GPUs: 
-### CPUs: 
-### Memory: 
-### Storage: 
+#### GPUs: 
+#### CPUs: 
+#### Memory: 
+#### Storage: 
 
-## Production Environment
-
-### Production Requirements
+### Integration
 
 Describe how the model will be integrated into the system; this likely includes descriptions of model deployment, application hosting, etc.
 
-### Inference Requirements 
+### Input Specification
 
-Describe the hardware and software requirements including amount of compute resources needed for inference.
+Describe the input data type and format needed for the model to conduct inference.
+
+### Output Specification
+
+Describe the output format and specification needed for the system to ingest model results.
+
+## Production Compute Resources
+
+Describe the hardware and software requirements for inference.
+
+#### GPUs: 
+#### CPUs: 
+#### Memory: 
+#### Storage: 
+
+### Other Considerations

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - 'MLTE Framework': 'mlte_framework.md'
     - 'MLTE Properties': 'properties.md'
     - 'MLTE Measurements': 'mlte_measurements.md'
+    - 'MLTE Negotiation Card': 'negotiation_card.md'
     - API Reference: reference/
   - 'Explanations':
     - 'MLTE Process Resources': 'mlte_process_resources.md'


### PR DESCRIPTION
Adds the MLTE negotiation card into the documentation as a reference.

Updated the paper version from arXiv to IEEE in our README, and updated all README links so that they now open in another tab (which is our default for the documentation).