### PR TITLE
Eager Structural Parent Elements Creation

### DIFF
--- a/mlte/session/state.py
+++ b/mlte/session/state.py
@@ -6,6 +6,7 @@ Session state management for the MLTE library.
 
 from typing import Optional
 
+import mlte.store.artifact.util as storeutil
 from mlte.context import Context
 from mlte.store.artifact.factory import create_store
 from mlte.store.artifact.store import ArtifactStore
@@ -53,6 +54,14 @@ class Session:
         """Set the session store."""
         self._store = store
 
+    def create_context(self):
+        """Creates the currently configured context in the currently configured session. Fails if either is not set. Does nothing if already created."""
+        store = self.store
+        context = self.context
+        storeutil.create_parents(
+            store.session(), context.model, context.version
+        )
+
 
 # Singleton session state
 g_session = Session()
@@ -63,14 +72,17 @@ def session() -> Session:
     return g_session
 
 
-def set_context(model_id: str, version_id: str):
+def set_context(model_id: str, version_id: str, lazy: bool = True):
     """
     Set the global MLTE context.
     :param model_id: The model identifier
     :param version_id: The version identifier
+    :param lazy: Whether to wait to create the context until an artifact is written (True), or to eagerly create it immediately (False).
     """
     global g_session
     g_session._set_context(Context(model_id, version_id))
+    if not lazy:
+        g_session.create_context()
 
 
 def set_store(artifact_store_uri: str):

--- a/test/session/test_session.py
+++ b/test/session/test_session.py
@@ -4,7 +4,18 @@ test/session/test_session.py
 Unit tests for global session management.
 """
 
+import pytest
+
 from mlte.session import session, set_context, set_store
+from mlte.store.artifact.store import ArtifactStore
+
+from ..store.artifact.fixture import (  # noqa
+    fs_store,
+    http_store,
+    memory_store,
+    rdbs_store,
+    stores,
+)
 
 
 def test_session() -> None:
@@ -20,3 +31,25 @@ def test_session() -> None:
     assert s.context.model == model
     assert s.context.version == version
     assert s.store.uri.uri == uri
+
+
+@pytest.mark.parametrize("store_fixture_name", stores())
+def test_eager_context_creation(
+    store_fixture_name: str, request: pytest.FixtureRequest
+) -> None:
+    # Ignore http_store for now, weird issue setting it up.
+    print(store_fixture_name)
+    if store_fixture_name == "http_store":
+        return
+
+    model = "model"
+    version = "v0.0.1"
+    store: ArtifactStore = request.getfixturevalue(store_fixture_name)
+
+    set_store(store.uri.uri)
+    set_context(model, version, lazy=False)
+
+    s = session()
+
+    assert s.store.session().read_model(model).identifier == model
+    assert s.store.session().read_version(model, version).identifier == version


### PR DESCRIPTION
Added optional functionality to eagerly create structural parent elements (model/version) for a context when using the MLTE library, either by calling a method or setting a param when setting the context. Addresses #335 .