### PR TITLE
Publish MLTE 0.2.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.8
+current_version = 0.2.9
 
 [bumpversion:file:./docs/docs/index.md]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,8 @@
 [bumpversion]
 current_version = 0.2.9
 
+[bumpversion:file:./README.md]
+
 [bumpversion:file:./docs/docs/index.md]
 
 [bumpversion:file:./pyproject.toml]

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ docs/site
 
 # Pyenv conf
 .python-version
+
+store/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `mlte` (pronounced "melt") is a framework and infrastructure for machine learning evaluation.
 
-![Version Badge](https://img.shields.io/badge/release-v0.2.8-e19b38)
+![Version Badge](https://img.shields.io/badge/release-v0.2.9-e19b38)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Tests](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml/badge.svg)](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml)
 [![Documentation Status](https://readthedocs.org/projects/mlte/badge/?version=latest)](https://mlte.readthedocs.io/en/latest/?badge=latest)

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -231,12 +231,6 @@ Build the static distribution for the front end; the command below assumes that 
 $ cd mlte/frontend/nuxt-app && npm run build
 ```
 
-If publishing on MacOS, you'll need to remove the node_modules directory before building the package (they can be reinstalled afterwards using `npm install`):
-
-```bash
-$ rm -rf mlte/frontend/nuxt-app/node_modules
-```
-
 Create the source distribution and wheel:
 
 ```bash

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -46,23 +46,25 @@ from mlte.report ... #importing from report subpackage
 
 ## Running the User Interface
 
-To run the user interface (UI), run the following in your command line:
+To run the user interface (UI or frontend), first you need to start the backend server. Running the backend can be done with the following command:
+
+```bash
+$ mlte backend
+```
+
+However, by default this will store any artifacts in a non-persistent, in-memory store. You also have the option to use a folder to store artifacts, or a relational database, using the `--store-uri` flag. For the latter, see the appropriate section below. For the former, you have to specify a relative or absolute folder path with the `fs://` prefix. For example, to run the backend with a store located in a folder called `store` relative to the folder where you are running mlte, you can run the backend like this:
+
+```bash
+$ mlte backend --store-uri fs://store
+```
+
+Once the backend is running, you can run the frontend with the following command:
+
 ```bash
 $ mlte ui
 ```
 
-In order for the frontend to be able to communicate with the backend you will need to allow the frontend as an origin.
-This can be done by specifying the `--allowed-origins` flag when running the backend. 
-When ran through the mlte package, the frontend will be hosted at `http://localhost:8000` so the backend command will look something like this:
-
-```bash
-$ mlte backend --store-uri fs://store --allowed-origins http://localhost:8000
-```
-
-In real deployments, you should define a new secret to be used for token signing, instead of the default one. This can be done by either creating and .env file with the secret string on the variable `JWT_SECRET_KEY="<secret_string>"`, or passing it as a command line argument with `--jwt-secret`.
-
-Once you run it, go to the hosted address to view the `MLTE` UI homepage. You will need to log in to access the functionality in the UI. To start with you can
-use the default user. You can later use the UI to set up new users as well.
+After this, go to the hosted address (defaults to `http://localhost:8000`) to view the `MLTE` UI homepage. You will need to log in to access the functionality in the UI. You can start using the default user. You can later use the UI to set up new users as well.
 
 NOTE: you should change the default user's password as soon as you can, if you are not on a local setup.
 
@@ -70,6 +72,13 @@ NOTE: you should change the default user's password as soon as you can, if you a
 * Default password: admin1234
 
 For more information on how to use the UI, see our how-to guide on [using `MLTE`](using_mlte.md).
+
+## Backend Considerations
+
+The backend comes with a default secret for signing authentication tokens. In real deployments, you should define a new secret to be used for token signing, instead of the default one. This can be done by either creating an `.env` file with the secret string on the variable `JWT_SECRET_KEY="<secret_string>"`, or passing it as a command line argument with the `--jwt-secret` flag.
+
+In order for the frontend to be able to communicate with the backend the frontend need to be allowed as an origin. This can be done by specifying the `--allowed-origins` flag when starting the backend. When ran through the mlte package, the frontend will be hosted at `http://localhost:8000`. This address is configured to be allowed by default, so the flag does not need to be used by default, but if the frontend is hosted on another address, this flag needs to be set with the correct address.
+
 
 ## Using a Relational DB Engine Backend
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -17,7 +17,7 @@ Welcome to the `MLTE` Documentation!
 
 ## More Information
 
-- Version: 0.2.8
+- Version: 0.2.9
 - Contact Email: mlte dot team dot info at gmail dot com
 - Citation: While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use `MLTE` for academic research.
 

--- a/mlte/backend/core/config.py
+++ b/mlte/backend/core/config.py
@@ -16,6 +16,9 @@ from mlte.store.base import StoreURIPrefix
 # An enumeration of supported log levels
 _LOG_LEVELS = ["DEBUG", "WARNING", "INFO", "ERROR", "CRITICAL"]
 
+# Default address for Frontend.
+DEFAULT_FRONTEND_ADDRESS = "http://localhost:8000"
+
 
 class Settings(BaseSettings):
     """
@@ -60,7 +63,7 @@ class Settings(BaseSettings):
             raise ValueError(f"Unsupported log level: {v}.")
         return v
 
-    ALLOWED_ORIGINS: List[str] = []
+    ALLOWED_ORIGINS: List[str] = [DEFAULT_FRONTEND_ADDRESS]
     """A list of allowed CORS origins."""
 
     JWT_SECRET_KEY: str = (

--- a/mlte/cli/.env
+++ b/mlte/cli/.env
@@ -1,9 +1,9 @@
 # Default values, commonly changed if in production environment
-ENVIRONMENT="default"
-APP_HOST="localhost"
-APP_PORT="8080"
 ALLOWED_ORIGINS='["http://localhost:3000"]'
 
+#ENVIRONMENT="default"
+#APP_HOST="localhost"
+#APP_PORT="8080"
 #JWT_SECRET_KEY=""
 #BACKEND_URI=""
 #LOG_LEVEL="ERROR"

--- a/mlte/cli/.gitignore
+++ b/mlte/cli/.gitignore
@@ -1,3 +1,0 @@
-models/
-users/
-store/

--- a/mlte/cli/cli.py
+++ b/mlte/cli/cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import sys
 import traceback
+from importlib.metadata import PackageNotFoundError, version
 
 import mlte.backend.main as backend
 import mlte.frontend as frontend
@@ -20,9 +21,20 @@ EXIT_FAILURE = 1
 # The global name of the program
 _PROGRAM_NAME = "mlte"
 
+# The name of the package.
+_PACKAGE_NAME = "mlte-python"
+
 # -----------------------------------------------------------------------------
 # Parsing Setup
 # -----------------------------------------------------------------------------
+
+
+def _get_version() -> str:
+    """Gets the version of the currently installed MLTE."""
+    try:
+        return version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return "<mlte is not installed as a package.>"
 
 
 def _prepare_parser():
@@ -30,6 +42,14 @@ def _prepare_parser():
 
     # The base parser
     base_parser = argparse.ArgumentParser(prog=_PROGRAM_NAME)
+
+    # Version flag.
+    base_parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
+    )
 
     # Attach subparsers
     subparser = base_parser.add_subparsers(help="Subcommands:")

--- a/mlte/frontend/nuxt-app/package.json
+++ b/mlte/frontend/nuxt-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "scripts": {
     "build": "nuxi generate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mlte-python"
-version = "0.2.8"
+version = "0.2.9"
 description = "An infrastructure for machine learning test and evaluation."
 authors = ["MLTE Engineers"]
 packages = [


### PR DESCRIPTION
Publishes MLTE 0.2.9 (already uploaded to PyPi).

 - Updated version number
 - Added --version flag to CLI to show the current version
 - Made localhost:8000 a default allowed-origin to simplify running of deployed frontend and backend
 - Updated getting_started doc with clearer instructions to run backend and frontend
 - Removed uneeded step in development doc for publishing