### PR TITLE
Updating version to 1.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 
 [bumpversion:file:./README.md]
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `mlte` (pronounced "melt") is a framework and infrastructure for machine learning evaluation.
 
-![Version Badge](https://img.shields.io/badge/release-v1.0.0-e19b38)
+![Version Badge](https://img.shields.io/badge/release-v1.0.1-e19b38)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Tests](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml/badge.svg)](https://github.com/turingcompl33t/mlte/actions/workflows/ci.yaml)
 [![Documentation Status](https://readthedocs.org/projects/mlte/badge/?version=latest)](https://mlte.readthedocs.io/en/latest/?badge=latest)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -44,7 +44,7 @@ If results are not satisfactory, more negotiation is required to determine if re
 
 ## MLTE Metadata
 
-- Version: 1.0.0
+- Version: 1.0.1
 - Contact Email: mlte dot team dot info at gmail dot com
 - Citations: While not required, it is highly encouraged and greatly appreciated if you cite our paper when you use `MLTE` for academic research.
 

--- a/mlte/frontend/nuxt-app/package.json
+++ b/mlte/frontend/nuxt-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "build": "nuxi generate",
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^18",
-    "@uswds/compile": "^1.0.0",
+    "@uswds/compile": "^1.0.1",
     "eslint": "^8.45.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.27.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.1"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "mlte-python"
-version = "1.0.0"
+version = "1.0.1"
 description = "An infrastructure for machine learning test and evaluation."
 authors = ["MLTE Engineers"]
 readme = "README.md"


### PR DESCRIPTION
Since we are starting work on major architectural changes, it would be good to create, tag and publish a small increment version to 1.0.0 that add the couple of improvements we have been working over the last few weeks. 

This specific PR just updates the version number to 1.0.1 so we can create a release and publish it with the proper version.

Btw, the fixes that this version will have once we create the release, which are currently in master but not in 1.0.0, include:
 - Fixes for the Frontend to properly work in a remotely deployed dockerized server (#405 and #418)
 - Bug fixes for creating docker image from Frontend
 - Fixes in configuration for readme to properly show up in PyPi website as the package description (#491)
 - Fixes in documentation to avoid inconsistencies in examples between documentation and demos (#461)