### PR TITLE
Bug/python 3.11.x ci support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5446,5 +5446,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9.1,<=3.11"
-content-hash = "6c66f48f3806aaf21ee0629277b852e8ccdb6a6e3ef3cb9d4cd46bf0f184c662"
+python-versions = ">=3.9.1,<3.12"
+content-hash = "ca0b715f539f5e3d8e51f6a4f9b4405f5112f7f0fa1c70cf7af19afebac565ca"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5446,5 +5446,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9.1,<=3.11.0"
-content-hash = "db98330b66ae38df4d69c65b57c9ba5576ea5b0ba8d11e74543fe6148278da83"
+python-versions = ">=3.9.1,<=3.11"
+content-hash = "6c66f48f3806aaf21ee0629277b852e8ccdb6a6e3ef3cb9d4cd46bf0f184c662"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = [
 mlte = "mlte.cli:run"
 
 [tool.poetry.dependencies]
-python = ">=3.9.1,<=3.11"
+python = ">=3.9.1,<3.12"
 fastapi = ">=0.100.0"
 pydantic-settings = "^2.0.3"
 pydantic = "^2.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = [
 mlte = "mlte.cli:run"
 
 [tool.poetry.dependencies]
-python = ">=3.9.1,<=3.11.0"
+python = ">=3.9.1,<=3.11"
 fastapi = ">=0.100.0"
 pydantic-settings = "^2.0.3"
 pydantic = "^2.1.1"


### PR DESCRIPTION
Addresses #550 by explicitly allowing all 3.11.x versions to work with MLTE in the pyproject restrictions.