### PR TITLE
Fixes Bug Printing Values to Result Messages in Validator

### DIFF
--- a/demo/simple/confusion_matrix.py
+++ b/demo/simple/confusion_matrix.py
@@ -43,7 +43,7 @@ class ConfusionMatrix(ValueBase):
         return self._equal(other)
 
     def __str__(self) -> str:
-        return f"{self.matrix}"
+        return f"{self.matrix}".replace("\n", ", ")
 
     @property
     def misclassifications(self) -> int:

--- a/mlte/validation/validator.py
+++ b/mlte/validation/validator.py
@@ -125,20 +125,37 @@ class Validator:
                     "Configured bool expression does not return a bool."
                 )
 
-        # Stringify arguments so that result's message can include generic information about arguments used when validating.
-        values = f"- values: {json.dumps(args) if len(args) > 0 else ''}{', ' if len(args) > 0 and len(kwargs) > 0 else ''}{json.dumps(kwargs) if len(kwargs) > 0 else ''}"
-
         # Create the result to be returned.
+        values_str = self._args_to_string(*args, **kwargs)
         result = (
             Info(self.info)
             if self.bool_exp is None and self.info is not None
             else (
-                Success(f"{self.success} {values}")
+                Success(f"{self.success} {values_str}")
                 if executed_bool_exp_value
-                else Failure(f"{self.failure} {values}")
+                else Failure(f"{self.failure} {values_str}")
             )
         )
         return result
+
+    def _args_to_string(self, *args, **kwargs) -> str:
+        """
+        Stringify arguments so that result's message can include generic information about arguments used when validating.
+        """
+        # First ensure args are turned to string separately, to allow them to use their own str()
+        str_args = [str(arg) for arg in args]
+        str_kwargs = {key: str(arg) for key, arg in kwargs.items()}
+
+        # Now string them together, depending on whether we got args of each type.
+        values = "- values: "
+        if len(args) > 0:
+            values = values + f"{json.dumps(str_args)}"
+        if len(args) > 0 and len(kwargs) > 0:
+            values = values + f"{', '}"
+        if len(kwargs) > 0:
+            values = values + f"{json.dumps(str_kwargs)}"
+
+        return values
 
     # -------------------------------------------------------------------------
     # Model handling.

--- a/test/validation/test_validator.py
+++ b/test/validation/test_validator.py
@@ -5,8 +5,10 @@ Unit tests for Validator.
 """
 
 from mlte._private.function_info import FunctionInfo
+from mlte.evidence.metadata import EvidenceMetadata, Identifier
 from mlte.validation.model_condition import ValidatorModel
 from mlte.validation.validator import Validator
+from mlte.value.types.integer import Integer
 
 
 def get_sample_validator(add_creator: bool = False) -> Validator:
@@ -96,7 +98,7 @@ def test_validate_success() -> None:
 
     assert (
         validator.success is not None
-        and result.message == validator.success + f" - values: [{x}, {y}]"
+        and result.message == validator.success + f' - values: ["{x}", "{y}"]'
     )
 
 
@@ -112,7 +114,7 @@ def test_validate_success_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message
-        == validator.success + f' - values: {{"x": {x}, "y": {y}}}'
+        == validator.success + f' - values: {{"x": "{x}", "y": "{y}"}}'
     )
 
 
@@ -128,7 +130,7 @@ def test_validate_success_args_and_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message
-        == validator.success + f' - values: [{x}], {{"y": {y}}}'
+        == validator.success + f' - values: ["{x}"], {{"y": "{y}"}}'
     )
 
 
@@ -143,7 +145,7 @@ def test_validate_failure() -> None:
 
     assert (
         validator.failure is not None
-        and result.message == validator.failure + f" - values: [{x}, {y}]"
+        and result.message == validator.failure + f' - values: ["{x}", "{y}"]'
     )
 
 
@@ -158,3 +160,23 @@ def test_validate_ignore() -> None:
     result = validator.validate(x, y)
 
     assert result.message == validator.info
+
+
+def test_validate_success_with_value() -> None:
+    """The validate() method works as expected with a Value."""
+
+    validator = Integer.less_or_equal_to(2).validator
+
+    result = validator.validate(
+        Integer(
+            value=1,
+            metadata=EvidenceMetadata(
+                measurement_type="test", identifier=Identifier(name="test")
+            ),
+        )
+    )
+
+    assert (
+        validator.success is not None
+        and result.message == validator.success + ' - values: ["1"]'
+    )


### PR DESCRIPTION
Validator: fixed bug where messages set to generated Results when valdating were not properly serializing Values, turning them into JSON instead of getting their internal values. Addresses #599. Now args are turned to strings before the arrays are dumped to JSON, letting a Value properly be converted to its string represenatation.