### PR TITLE
Bug/clean fs store names

### DIFF
--- a/mlte/_private/file.py
+++ b/mlte/_private/file.py
@@ -1,0 +1,16 @@
+REPLACE_CHARS = {"/": "__"}
+"""Chars that need replacing, and their replacements."""
+
+
+def make_valid_filename(filename: str) -> str:
+    """Cleans the given filename so it is a valid one."""
+    for char, replacement in REPLACE_CHARS.items():
+        filename = filename.replace(char, replacement)
+    return filename
+
+
+def revert_valid_filename(filename: str) -> str:
+    """Undo the cleanup done by make_valid_filename."""
+    for char, replacement in REPLACE_CHARS.items():
+        filename = filename.replace(replacement, char)
+    return filename

--- a/mlte/_private/file.py
+++ b/mlte/_private/file.py
@@ -1,16 +1,18 @@
-REPLACE_CHARS = {"/": "__"}
+"""
+Various file-related utils.
+"""
+
+from mlte._private import text
+
+VALID_FILE_REPLACEMENTS = {"/": "___"}
 """Chars that need replacing, and their replacements."""
 
 
 def make_valid_filename(filename: str) -> str:
     """Cleans the given filename so it is a valid one."""
-    for char, replacement in REPLACE_CHARS.items():
-        filename = filename.replace(char, replacement)
-    return filename
+    return text.replace_all(filename, VALID_FILE_REPLACEMENTS)
 
 
 def revert_valid_filename(filename: str) -> str:
     """Undo the cleanup done by make_valid_filename."""
-    for char, replacement in REPLACE_CHARS.items():
-        filename = filename.replace(replacement, char)
-    return filename
+    return text.replace_all(filename, VALID_FILE_REPLACEMENTS, revert=True)

--- a/mlte/_private/text.py
+++ b/mlte/_private/text.py
@@ -1,6 +1,4 @@
-"""
-Internal utilities for handling text.
-"""
+"""Internal utilities for handling text."""
 
 import textwrap
 
@@ -26,7 +24,7 @@ def replace_all(
 
     :param main_string: the string to do the replacements on.
     :param replacement: a dict of substrings and their replacements.
-    :param rever: if true, revert how the replacements dict is used: the replacements will be found and replaced with the substrings.
+    :param revert: if true, revert how the replacements dict is used: the replacements will be found and replaced with the substrings.
     """
     for substring, replacement in replacements.items():
         if not revert:

--- a/mlte/_private/text.py
+++ b/mlte/_private/text.py
@@ -1,6 +1,4 @@
 """
-mlte/_private/text.py
-
 Internal utilities for handling text.
 """
 
@@ -18,3 +16,24 @@ def cleantext(text: str) -> str:
     :rtype: str
     """
     return " ".join(textwrap.dedent(text).strip().split("\n"))
+
+
+def replace_all(
+    main_string: str, replacements: dict[str, str], revert: bool = False
+) -> str:
+    """
+    Replaces all instances of the given strings with the provided replacements.
+
+    :param main_string: the string to do the replacements on.
+    :param replacement: a dict of substrings and their replacements.
+    :param rever: if true, revert how the replacements dict is used: the replacements will be found and replaced with the substrings.
+    """
+    for substring, replacement in replacements.items():
+        if not revert:
+            to_find = substring
+            to_put = replacement
+        else:
+            to_find = replacement
+            to_put = substring
+        main_string = main_string.replace(to_find, to_put)
+    return main_string

--- a/mlte/_private/url.py
+++ b/mlte/_private/url.py
@@ -1,6 +1,8 @@
 from typing import Optional, Tuple
 from urllib.parse import ParseResult, quote, urlparse
 
+from mlte._private import text
+
 
 def set_url_username_password(url: str, username: str, password: str) -> str:
     """Adds the given username and password to an URL."""
@@ -27,3 +29,20 @@ def remove_url_username_password(
         url = clear_uri.geturl()
 
     return url, parsed_uri.username, parsed_uri.password
+
+
+# --------------------------------------------------------------------------------------------------------------
+# URL parsing.
+# --------------------------------------------------------------------------------------------------------------
+
+VALID_URL_PATH_CHARS = {"/": "---"}
+
+
+def make_valid_url_part(path_part: str) -> str:
+    """Makes a part of a URL path valid."""
+    return text.replace_all(path_part, VALID_URL_PATH_CHARS)
+
+
+def revert_valid_url_part(path_part: str) -> str:
+    """Makes a part of a URL path valid."""
+    return text.replace_all(path_part, VALID_URL_PATH_CHARS, revert=True)

--- a/mlte/backend/api/endpoints/artifact.py
+++ b/mlte/backend/api/endpoints/artifact.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException
 
 import mlte.backend.api.codes as codes
 import mlte.store.error as errors
+from mlte._private import url as url_utils
 from mlte.artifact.model import ArtifactModel
 from mlte.backend.api.auth.authorization import AuthorizedUser
 from mlte.backend.api.error_handlers import raise_http_internal_error
@@ -40,6 +41,8 @@ def write_artifact(
     :param request: The artifact write request
     :return: The created artifact
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
     with state_stores.artifact_store_session() as artifact_store:
         try:
             artifact = artifact_store.write_artifact_with_header(
@@ -77,6 +80,9 @@ def read_artifact(
     :param artifact_id: The identifier for the artifact
     :return: The read artifact
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
+    artifact_id = url_utils.revert_valid_url_part(artifact_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.read_artifact(model_id, version_id, artifact_id)
@@ -104,6 +110,8 @@ def read_artifacts(
     :param offset: The offset on returned artifacts
     :return: The read artifacts
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.read_artifacts(model_id, version_id, limit, offset)
@@ -128,6 +136,8 @@ def search_artifacts(
     :param query: The artifact query
     :return: The read artifacts
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.search_artifacts(model_id, version_id, query)
@@ -149,6 +159,9 @@ def delete_artifact(
     :param artifact_id: The identifier for the artifact
     :return: The deleted artifact
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
+    artifact_id = url_utils.revert_valid_url_part(artifact_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.delete_artifact(model_id, version_id, artifact_id)

--- a/mlte/backend/api/endpoints/catalog_entry.py
+++ b/mlte/backend/api/endpoints/catalog_entry.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException
 
 import mlte.backend.api.codes as codes
 import mlte.store.error as errors
+from mlte._private import url as url_utils
 from mlte.backend.api.auth.authorization import AuthorizedUser
 from mlte.backend.api.error_handlers import raise_http_internal_error
 from mlte.backend.api.models.catalog import CatalogReply
@@ -31,6 +32,7 @@ def create_catalog_entry(
     :param entry: The catalog entry to create
     :return: The created catalog entry
     """
+    catalog_id = url_utils.revert_valid_url_part(catalog_id)
     with state_stores.catalog_stores_session() as catalog_stores:
         try:
             if not entry.header.catalog_id:
@@ -73,6 +75,7 @@ def edit_catalog_entry(
     :param entry: The entry to edit
     :return: The edited entry
     """
+    catalog_id = url_utils.revert_valid_url_part(catalog_id)
     with state_stores.catalog_stores_session() as catalog_stores:
         try:
             if not entry.header.catalog_id:
@@ -111,6 +114,8 @@ def read_catalog_entry(
     :param catalog_entry_id: The entry name
     :return: The read entry
     """
+    catalog_id = url_utils.revert_valid_url_part(catalog_id)
+    catalog_entry_id = url_utils.revert_valid_url_part(catalog_entry_id)
     with state_stores.catalog_stores_session() as catalog_stores:
         try:
             return catalog_stores.get_session(catalog_id).entry_mapper.read(
@@ -136,6 +141,8 @@ def delete_catalog_entry(
     :param catalog_entry_id: The entry id
     :return: The deleted entry
     """
+    catalog_id = url_utils.revert_valid_url_part(catalog_id)
+    catalog_entry_id = url_utils.revert_valid_url_part(catalog_entry_id)
     with state_stores.catalog_stores_session() as catalog_stores:
         try:
             catalog_session = catalog_stores.get_session(catalog_id)
@@ -167,6 +174,7 @@ def list_catalog_entries(
     List MLTE catalog entries, with details for each entry.
     :return: A collection of entries with their details.
     """
+    catalog_id = url_utils.revert_valid_url_part(catalog_id)
     with state_stores.catalog_stores_session() as catalog_stores:
         try:
             return catalog_stores.get_session(

--- a/mlte/backend/api/endpoints/context.py
+++ b/mlte/backend/api/endpoints/context.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException
 
 import mlte.backend.api.codes as codes
 import mlte.store.error as errors
+from mlte._private import url as url_utils
 from mlte.backend.api.auth.authorization import AuthorizedUser
 from mlte.backend.api.error_handlers import raise_http_internal_error
 from mlte.backend.core import state_stores
@@ -76,6 +77,7 @@ def read_model(
     :param model_id: The model identifier
     :return: The read model
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
     try:
         with state_stores.artifact_store_session() as handle:
             model = handle.read_model(model_id)
@@ -119,6 +121,7 @@ def delete_model(
     :param model_id: The model identifier
     :return: The deleted model
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
     deleted_model: Model
     with state_stores.artifact_store_session() as handle:
         try:
@@ -157,6 +160,7 @@ def create_version(
     :param version: The version create model
     :return: The created version
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.create_version(model_id, version)
@@ -185,6 +189,8 @@ def read_version(
     :param version_id: The version identifier
     :return: The read version
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.read_version(model_id, version_id)
@@ -206,6 +212,7 @@ def list_versions(
     :param model_id: The model identifier
     :return: A collection of version identifiers
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.list_versions(model_id)
@@ -230,6 +237,8 @@ def delete_version(
     :param version_id: The version identifier
     :return: The deleted version
     """
+    model_id = url_utils.revert_valid_url_part(model_id)
+    version_id = url_utils.revert_valid_url_part(version_id)
     with state_stores.artifact_store_session() as handle:
         try:
             return handle.delete_version(model_id, version_id)

--- a/mlte/custom_list/custom_list_names.py
+++ b/mlte/custom_list/custom_list_names.py
@@ -27,7 +27,7 @@ class CustomListNameDict(dict[CustomListName, CustomListName]):
         else:
             raise KeyError(f"CustomListName {key} or {value} is not valid.")
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> CustomListName:
         if key in CustomListName._value2member_map_:
             return super().__getitem__(key)
         else:

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
@@ -115,7 +115,6 @@
           "type": "string"
         },
         "data": {
-          "additionalProperties": true,
           "title": "Data",
           "type": "object"
         }

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/value/v0.0.1/schema.json
@@ -115,6 +115,7 @@
           "type": "string"
         },
         "data": {
+          "additionalProperties": true,
           "title": "Data",
           "type": "object"
         }

--- a/mlte/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/schema/artifact/value/v0.0.1/schema.json
@@ -115,7 +115,6 @@
           "type": "string"
         },
         "data": {
-          "additionalProperties": true,
           "title": "Data",
           "type": "object"
         }

--- a/mlte/schema/artifact/value/v0.0.1/schema.json
+++ b/mlte/schema/artifact/value/v0.0.1/schema.json
@@ -115,6 +115,7 @@
           "type": "string"
         },
         "data": {
+          "additionalProperties": true,
           "title": "Data",
           "type": "object"
         }

--- a/mlte/store/artifact/underlying/http.py
+++ b/mlte/store/artifact/underlying/http.py
@@ -1,6 +1,4 @@
 """
-mlte/store/artifact/underlying/http.py
-
 Implementation of HTTP artifact store.
 """
 
@@ -11,16 +9,13 @@ from typing import List, Optional
 
 from mlte.artifact.model import ArtifactModel
 from mlte.backend.api.models.artifact_model import WriteArtifactRequest
-from mlte.backend.core.config import settings
 from mlte.context.model import Model, Version
 from mlte.store.artifact.store import ArtifactStore, ArtifactStoreSession
 from mlte.store.base import StoreURI
 from mlte.store.common.http_clients import OAuthHttpClient
 from mlte.store.common.http_storage import HttpStorage
 from mlte.store.query import Query
-
-API_PREFIX = settings.API_PREFIX
-"""API URL prefix."""
+from mlte.user.model import ResourceType
 
 # -----------------------------------------------------------------------------
 # HttpArtifactStore
@@ -35,7 +30,9 @@ class HttpArtifactStore(ArtifactStore):
     ) -> None:
         super().__init__(uri=uri)
 
-        self.storage = HttpStorage(uri=uri, client=client)
+        self.storage = HttpStorage(
+            uri=uri, resource_type=ResourceType.MODEL, client=client
+        )
         """HTTP storage."""
 
     def session(self) -> HttpArtifactStoreSession:
@@ -55,78 +52,60 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
     """An HTTP implementation of the MLTE artifact store session."""
 
     def __init__(self, *, storage: HttpStorage) -> None:
-        """The remote artifact store URL."""
-        self.url = storage.clean_url
-        """URL."""
+        self.storage = storage
+        """HTTP Storage."""
 
-        self.client = storage.client
-        """Storage."""
-
-        storage.start_session()
+        self.storage.start_session()
 
     def close(self):
         # No closing needed.
         pass
 
     # -------------------------------------------------------------------------
-    # Structural Elements
+    # Model
     # -------------------------------------------------------------------------
 
     def create_model(self, model: Model) -> Model:
-        url = f"{self.url}{API_PREFIX}/model"
-        res = self.client.post(url, json=model.to_json())
-        self.client.raise_for_response(res)
-
-        return Model(**res.json())
+        response = self.storage.post(resource_url="", json=model.to_json())
+        return Model(**response)
 
     def read_model(self, model_id: str) -> Model:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return Model(**res.json())
+        response = self.storage.get(resource_url=f"/{model_id}")
+        return Model(**response)
 
     def list_models(self) -> List[str]:
-        url = f"{self.url}{API_PREFIX}/model"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return typing.cast(List[str], res.json())
+        response = self.storage.get(resource_url="")
+        return typing.cast(List[str], response)
 
     def delete_model(self, model_id: str) -> Model:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}"
-        res = self.client.delete(url)
-        self.client.raise_for_response(res)
+        response = self.storage.delete(resource_url=f"/{model_id}")
+        return Model(**response)
 
-        return Model(**res.json())
+    # -------------------------------------------------------------------------
+    # Version
+    # -------------------------------------------------------------------------
 
     def create_version(self, model_id: str, version: Version) -> Version:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}/version"
-        res = self.client.post(url, json=version.to_json())
-        self.client.raise_for_response(res)
-
-        return Version(**res.json())
+        response = self.storage.post(
+            resource_url=f"/{model_id}/version", json=version.to_json()
+        )
+        return Version(**response)
 
     def read_version(self, model_id: str, version_id: str) -> Version:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}/version/{version_id}"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return Version(**res.json())
+        response = self.storage.get(
+            resource_url=f"/{model_id}/version/{version_id}"
+        )
+        return Version(**response)
 
     def list_versions(self, model_id: str) -> List[str]:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}/version"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return typing.cast(List[str], res.json())
+        response = self.storage.get(resource_url=f"/{model_id}/version")
+        return typing.cast(List[str], response)
 
     def delete_version(self, model_id: str, version_id: str) -> Version:
-        url = f"{self.url}{API_PREFIX}/model/{model_id}/version/{version_id}"
-        res = self.client.delete(url)
-        self.client.raise_for_response(res)
-
-        return Version(**res.json())
+        response = self.storage.delete(
+            resource_url=f"/{model_id}/version/{version_id}"
+        )
+        return Version(**response)
 
     # -------------------------------------------------------------------------
     # Artifacts
@@ -141,16 +120,14 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
         force: bool = False,
         parents: bool = False,
     ) -> ArtifactModel:
-        url = f"{_url(self.url, model_id, version_id)}/artifact"
-        res = self.client.post(
+        url = f"{_url(model_id, version_id)}/artifact"
+        response = self.storage.post(
             url,
             json=WriteArtifactRequest(
                 artifact=artifact, force=force, parents=parents
             ).to_json(),
         )
-        self.client.raise_for_response(res)
-
-        return ArtifactModel(**(res.json()["artifact"]))
+        return ArtifactModel(**(response["artifact"]))
 
     def read_artifact(
         self,
@@ -158,11 +135,9 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
         version_id: str,
         artifact_id: str,
     ) -> ArtifactModel:
-        url = f"{_url(self.url, model_id, version_id)}/artifact/{artifact_id}"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return ArtifactModel(**res.json())
+        url = f"{_url(model_id, version_id)}/artifact/{artifact_id}"
+        response = self.storage.get(url)
+        return ArtifactModel(**response)
 
     def read_artifacts(
         self,
@@ -171,11 +146,9 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
         limit: int = 100,
         offset: int = 0,
     ) -> List[ArtifactModel]:
-        url = f"{_url(self.url, model_id, version_id)}/artifact?limit={limit}&offset={offset}"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
-
-        return [ArtifactModel(**object) for object in res.json()]
+        url = f"{_url(model_id, version_id)}/artifact?limit={limit}&offset={offset}"
+        response = self.storage.get(url)
+        return [ArtifactModel(**object) for object in response]
 
     def search_artifacts(
         self,
@@ -184,11 +157,9 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
         query: Query = Query(),
     ) -> List[ArtifactModel]:
         # NOTE(Kyle): This operation always uses the "advanced search" functionality
-        url = f"{_url(self.url, model_id, version_id)}/artifact/search"
-        res = self.client.post(url, json=query.to_json())
-        self.client.raise_for_response(res)
-
-        return [ArtifactModel(**object) for object in res.json()]
+        url = f"{_url(model_id, version_id)}/artifact/search"
+        response = self.storage.post(url, json=query.to_json())
+        return [ArtifactModel(**object) for object in response]
 
     def delete_artifact(
         self,
@@ -196,19 +167,16 @@ class HttpArtifactStoreSession(ArtifactStoreSession):
         version_id: str,
         artifact_id: str,
     ) -> ArtifactModel:
-        url = f"{_url(self.url, model_id, version_id)}/artifact/{artifact_id}"
-        res = self.client.delete(url)
-        self.client.raise_for_response(res)
-
-        return ArtifactModel(**res.json())
+        url = f"{_url(model_id, version_id)}/artifact/{artifact_id}"
+        response = self.storage.delete(url)
+        return ArtifactModel(**response)
 
 
-def _url(base: str, model_id: str, version_id: str) -> str:
+def _url(model_id: str, version_id: str) -> str:
     """
     Format a URL.
-    :param base: The base URL
     :param model_id: The model identifier
     :param version_id: The version identifier
     :return: The formatted URL
     """
-    return f"{base}{API_PREFIX}/model/{model_id}/version/{version_id}"
+    return f"/{model_id}/version/{version_id}"

--- a/mlte/store/catalog/underlying/fs.py
+++ b/mlte/store/catalog/underlying/fs.py
@@ -97,7 +97,7 @@ class FileSystemCatalogEntryMapper(CatalogEntryMapper):
         self.storage = storage.clone()
         """A reference to underlying storage."""
 
-        self.storage.set_base_path(
+        self.storage.setup_base_path(
             Path(self.storage.sub_folder, self.ENTRIES_FOLDER)
         )
         """Set the subfolder for this resource."""

--- a/mlte/store/catalog/underlying/http.py
+++ b/mlte/store/catalog/underlying/http.py
@@ -15,7 +15,7 @@ from mlte.store.catalog.store import (
 )
 from mlte.store.common.http_clients import OAuthHttpClient
 from mlte.store.common.http_storage import HttpStorage
-from mlte.user.model import ResourceType
+from mlte.user.model import MethodType, ResourceType
 
 ENTRY_URL_KEY = "entry"
 
@@ -150,11 +150,13 @@ class HTTPCatalogGroupEntryMapper(CatalogEntryMapper):
         limit: int = CatalogEntryMapper.DEFAULT_LIST_LIMIT,
         offset: int = 0,
     ) -> List[CatalogEntry]:
-        # Note: this is hacky, due to the hacky url being used to get details: catalogs/entry
-        self.storage.base_url += "s"
-        response = self.storage.get(id="entry")
-        self.storage.base_url = self.storage.base_url[:-1]
-
+        # This is a bit hacky, in that we have a pseudo resource type "catalogs",
+        # and a pseudo resource id "entry" to get all details of all entries.
+        response = self.storage.send_command(
+            MethodType.GET,
+            id="entry",
+            resource_type=f"{ResourceType.CATALOG.value}s",
+        )
         return [
             self._convert_to_remote(CatalogEntry(**entry)) for entry in response
         ][offset : offset + limit]

--- a/mlte/store/catalog/underlying/http.py
+++ b/mlte/store/catalog/underlying/http.py
@@ -1,6 +1,4 @@
 """
-mlte/store/catalog/underlying/http.py
-
 Implementation of HTTP catalog store group.
 """
 
@@ -8,7 +6,6 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Tuple
 
-from mlte.backend.core.config import settings
 from mlte.catalog.model import CatalogEntry
 from mlte.store.base import StoreURI
 from mlte.store.catalog.store import (
@@ -19,9 +16,6 @@ from mlte.store.catalog.store import (
 from mlte.store.common.http_clients import OAuthHttpClient
 from mlte.store.common.http_storage import HttpStorage
 from mlte.user.model import ResourceType
-
-API_PREFIX = settings.API_PREFIX
-"""API URL prefix."""
 
 
 # -----------------------------------------------------------------------------
@@ -41,7 +35,9 @@ class HttpCatalogGroupStore(CatalogStore):
     ) -> None:
         super().__init__(uri=uri)
 
-        self.storage = HttpStorage(uri=uri, client=client)
+        self.storage = HttpStorage(
+            uri=uri, resource_type=ResourceType.CATALOG, client=client
+        )
         """HTTP storage."""
 
     def session(self) -> CatalogStoreSession:
@@ -71,9 +67,7 @@ class HttpCatalogGroupStoreSession(CatalogStoreSession):
         self.read_only = read_only
         """Whether this is read only or not."""
 
-        self.entry_mapper = HTTPCatalogGroupEntryMapper(
-            url=self.storage.clean_url, client=self.storage.client
-        )
+        self.entry_mapper = HTTPCatalogGroupEntryMapper(storage=self.storage)
         """The mapper to entries CRUD."""
 
         storage.start_session()
@@ -93,26 +87,19 @@ class HTTPCatalogGroupEntryMapper(CatalogEntryMapper):
 
     COMPOSITE_ID_SEPARATOR = "--"
 
-    def __init__(self, url: str, client: OAuthHttpClient) -> None:
-        self.url = url
-        """The remote catalog store URL."""
-
-        self.client = client
-        """A reference to underlying HTTP client."""
-
-        self.base_url = f"{self.url}{API_PREFIX}/{ResourceType.CATALOG.value}"
-        """Base URL used in mapper."""
+    def __init__(self, storage: HttpStorage) -> None:
+        self.storage = storage
+        """The HTTP storage access."""
 
     def create(self, entry: CatalogEntry, context: Any = None) -> CatalogEntry:
         # Entry id contains the remote catalog id as well.
         local_catalog_id, _ = self.split_ids(entry.header.identifier)
         new_entry = self._convert_to_local(entry)
 
-        url = f"{self.base_url}/{local_catalog_id}/entry"
-        res = self.client.post(url, json=new_entry.to_json())
-        self.client.raise_for_response(res)
+        url = f"/{local_catalog_id}/entry"
+        response = self.storage.post(url, json=new_entry.to_json())
 
-        local_entry = CatalogEntry(**(res.json()))
+        local_entry = CatalogEntry(**response)
         return self._convert_to_remote(local_entry)
 
     def edit(self, entry: CatalogEntry, context: Any = None) -> CatalogEntry:
@@ -120,22 +107,20 @@ class HTTPCatalogGroupEntryMapper(CatalogEntryMapper):
         local_catalog_id, _ = self.split_ids(entry.header.identifier)
         edited_entry = self._convert_to_local(entry)
 
-        url = f"{self.base_url}/{local_catalog_id}/entry"
-        res = self.client.put(url, json=edited_entry.to_json())
-        self.client.raise_for_response(res)
+        url = f"/{local_catalog_id}/entry"
+        response = self.storage.put(url, json=edited_entry.to_json())
 
-        local_entry = CatalogEntry(**(res.json()))
+        local_entry = CatalogEntry(**response)
         return self._convert_to_remote(local_entry)
 
     def read(
         self, catalog_and_entry_id: str, context: Any = None
     ) -> CatalogEntry:
         catalog_id, entry_id = self.split_ids(catalog_and_entry_id)
-        url = f"{self.base_url}/{catalog_id}/entry/{entry_id}"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
+        url = f"/{catalog_id}/entry/{entry_id}"
+        response = self.storage.get(url)
 
-        local_entry = CatalogEntry(**(res.json()))
+        local_entry = CatalogEntry(**response)
         return self._convert_to_remote(local_entry)
 
     def list(self, context: Any = None) -> List[str]:
@@ -147,11 +132,10 @@ class HTTPCatalogGroupEntryMapper(CatalogEntryMapper):
     ) -> CatalogEntry:
         local_catalog_id, entry_id = self.split_ids(catalog_and_entry_id)
 
-        url = f"{self.base_url}/{local_catalog_id}/entry/{entry_id}"
-        res = self.client.delete(url)
-        self.client.raise_for_response(res)
+        url = f"/{local_catalog_id}/entry/{entry_id}"
+        response = self.storage.delete(url)
 
-        local_entry = CatalogEntry(**(res.json()))
+        local_entry = CatalogEntry(**response)
         return self._convert_to_remote(local_entry)
 
     def list_details(
@@ -160,13 +144,11 @@ class HTTPCatalogGroupEntryMapper(CatalogEntryMapper):
         limit: int = CatalogEntryMapper.DEFAULT_LIST_LIMIT,
         offset: int = 0,
     ) -> List[CatalogEntry]:
-        url = f"{self.base_url}s/entry"
-        res = self.client.get(url)
-        self.client.raise_for_response(res)
+        url = "s/entry"
+        response = self.storage.get(url)
 
         return [
-            self._convert_to_remote(CatalogEntry(**entry))
-            for entry in res.json()
+            self._convert_to_remote(CatalogEntry(**entry)) for entry in response
         ][offset : offset + limit]
 
     @staticmethod

--- a/mlte/store/common/fs_storage.py
+++ b/mlte/store/common/fs_storage.py
@@ -237,9 +237,9 @@ class FileSystemStorage(Storage):
 
     def _resource_group_path(self, group_ids: list[str]) -> Path:
         """
-        Gets the full path for a list of resource groups, to the last group in the list.
+        Gets the full path for a list of nested resource groups, including all groups list, in order.
         :param group_ids: An ordered list of nested resource groups.
-        :return: The formatted, cleaned, full path to the last group in the list.
+        :return: The formatted, cleaned, full path, up to the last group in the list.
         """
         full_path = self.base_path
         for group_id in group_ids:

--- a/mlte/store/common/fs_storage.py
+++ b/mlte/store/common/fs_storage.py
@@ -1,6 +1,4 @@
 """
-mlte/store/common/fs.py
-
 Common functions for file-based stores.
 """
 
@@ -8,9 +6,10 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Optional
 
 import mlte.store.error as errors
+from mlte._private import file
 from mlte._private.fixed_json import json
 from mlte.store.base import StoreType, StoreURI
 from mlte.store.common.storage import Storage
@@ -28,8 +27,8 @@ def parse_root_path(uri: StoreURI) -> Path:
     return Path(uri.path)
 
 
-class JsonFileStorage:
-    """A simple JSON storage wrapper for a file system store."""
+class JsonFileFS:
+    """A simple wrapper for common functions dealing with JSON files and folders."""
 
     JSON_EXT = ".json"
 
@@ -38,7 +37,7 @@ class JsonFileStorage:
         Path.mkdir(path, parents=True)
 
     @staticmethod
-    def list_folders(path: Path) -> List[Path]:
+    def list_folders(path: Path) -> list[Path]:
         return [x for x in sorted(path.iterdir()) if x.is_dir()]
 
     @staticmethod
@@ -46,21 +45,21 @@ class JsonFileStorage:
         shutil.rmtree(path)
 
     @staticmethod
-    def list_json_files(path: Path) -> List[Path]:
+    def list_json_files(path: Path) -> list[Path]:
         return [
             x
             for x in sorted(path.iterdir())
-            if x.is_file() and x.suffix == JsonFileStorage.JSON_EXT
+            if x.is_file() and x.suffix == JsonFileFS.JSON_EXT
         ]
 
     @staticmethod
-    def read_json_file(path: Path) -> Dict[str, Any]:
+    def read_json_file(path: Path) -> dict[str, Any]:
         with path.open("r") as f:
-            data: Dict[str, Any] = json.load(f)
+            data: dict[str, Any] = json.load(f)
         return data
 
     @staticmethod
-    def write_json_to_file(path: Path, data: Dict[str, Any]) -> None:
+    def write_json_to_file(path: Path, data: dict[str, Any]) -> None:
         with path.open("w") as f:
             json.dump(data, f, indent=4)
 
@@ -72,14 +71,18 @@ class JsonFileStorage:
 
     @staticmethod
     def add_extension(filename: str) -> Path:
-        return Path(filename + JsonFileStorage.JSON_EXT)
+        return Path(filename + JsonFileFS.JSON_EXT)
 
     @staticmethod
     def get_just_filename(path: Path) -> str:
         return path.stem
 
+    @staticmethod
+    def get_last_folder(path: Path) -> str:
+        return path.resolve().name
 
-class FileSystemStorage(Storage, JsonFileStorage):
+
+class FileSystemStorage(Storage):
     """A local file system implementation of a storage."""
 
     def __init__(self, uri: StoreURI, sub_folder: str) -> None:
@@ -96,16 +99,16 @@ class FileSystemStorage(Storage, JsonFileStorage):
         self.sub_folder = sub_folder
         """The specific folder for this storage."""
 
-        self.set_base_path(Path(sub_folder))
+        self.setup_base_path(Path(sub_folder))
 
-    def set_base_path(self, sub_folder: Path):
-        """Sets a base path for this storage based on the root and the given Path"""
+    def setup_base_path(self, sub_folder: Path):
+        """Sets a base path for this storage based on the root and the given Path."""
 
         self.base_path = Path(self.root, sub_folder)
         """The the base folder for the file store."""
 
         try:
-            JsonFileStorage.create_folder(self.base_path)
+            JsonFileFS.create_folder(self.base_path)
         except FileExistsError:
             # If it already existed, we just ignore warning.
             pass
@@ -118,52 +121,103 @@ class FileSystemStorage(Storage, JsonFileStorage):
     # Resource methods.
     # -------------------------------------------------------------------------
 
-    def list_resources(self) -> List[str]:
+    def list_resources(self, base_path: Optional[Path] = None) -> list[str]:
         """Returns a list of resource ids in this storage."""
+        base_path = self.base_path if not base_path else base_path
         return [
             self._resource_id(resource_path)
-            for resource_path in JsonFileStorage.list_json_files(self.base_path)
+            for resource_path in JsonFileFS.list_json_files(base_path)
         ]
 
-    def read_resource(self, resource_id: str) -> Dict[str, Any]:
+    def read_resource(
+        self, resource_id: str, base_path: Optional[Path] = None
+    ) -> dict[str, Any]:
         """Reads the given resource as a dict."""
-        return JsonFileStorage.read_json_file(self._resource_path(resource_id))
-
-    def write_resource(
-        self, resource_id: str, resource_data: Dict[str, Any]
-    ) -> None:
-        """Writes the given resource to storage."""
-        JsonFileStorage.write_json_to_file(
-            self._resource_path(resource_id), resource_data
+        return JsonFileFS.read_json_file(
+            self._resource_path(resource_id, base_path)
         )
 
-    def delete_resource(self, resource_id: str) -> None:
-        """Deletes the file for the associated resource id."""
-        JsonFileStorage.delete_file(self._resource_path(resource_id))
+    def write_resource(
+        self,
+        resource_id: str,
+        resource_data: dict[str, Any],
+        base_path: Optional[Path] = None,
+    ) -> None:
+        """Writes the given resource to storage."""
+        JsonFileFS.write_json_to_file(
+            self._resource_path(resource_id, base_path), resource_data
+        )
 
-    def ensure_resource_does_not_exist(self, resource_id: str) -> None:
+    def delete_resource(
+        self, resource_id: str, base_path: Optional[Path] = None
+    ) -> None:
+        """Deletes the file for the associated resource id."""
+        JsonFileFS.delete_file(self._resource_path(resource_id, base_path))
+
+    def ensure_resource_does_not_exist(
+        self, resource_id: str, base_path: Optional[Path] = None
+    ) -> None:
         """Throws an ErrorAlreadyExists if the given resource does exist."""
-        if self._resource_path(resource_id).exists():
+        if self._resource_path(resource_id, base_path).exists():
             raise errors.ErrorAlreadyExists(
                 f"Resource already exists: {resource_id}"
             )
 
-    def ensure_resource_exists(self, resource_id: str) -> None:
+    def ensure_resource_exists(
+        self, resource_id: str, base_path: Optional[Path] = None
+    ) -> None:
         """Throws an ErrorNotFound if the given resource does not exist."""
-        if not self._resource_path(resource_id).exists():
+        if not self._resource_path(resource_id, base_path).exists():
             raise errors.ErrorNotFound(f"Resource not found: {resource_id}")
+
+    # -------------------------------------------------------------------------
+    # Resource group methods.
+    # -------------------------------------------------------------------------
+
+    def create_resource_group(
+        self, group_id: str, base_path: Optional[Path] = None
+    ) -> None:
+        """Creates a resource group (folder)"""
+        path = self._resource_group_path(group_id, base_path)
+        JsonFileFS.create_folder(path)
+
+    def list_resource_groups(
+        self, base_path: Optional[Path] = None
+    ) -> list[str]:
+        """List the resource groups in a given path, or on the default one."""
+        base_path = self.base_path if not base_path else base_path
+        return [
+            self._resource_group_id(model_path.relative_to(base_path))
+            for model_path in JsonFileFS.list_folders(base_path)
+        ]
+
+    def exists_resource_group(
+        self, group_id: str, base_path: Optional[Path] = None
+    ) -> bool:
+        """Checks if the given resource group exists."""
+        return self._resource_group_path(group_id, base_path).exists()
+
+    def delete_resource_group(
+        self, group_id: str, base_path: Optional[Path] = None
+    ) -> None:
+        """Removes the given resource group."""
+        JsonFileFS.delete_folder(self._resource_group_path(group_id, base_path))
 
     # -------------------------------------------------------------------------
     # Internal helpers.
     # -------------------------------------------------------------------------
 
-    def _resource_path(self, resource_id: str) -> Path:
+    def _resource_path(
+        self, resource_id: str, base_path: Optional[Path] = None
+    ) -> Path:
         """
         Gets the full filepath for a stored resource.
         :param resource_id: The resource identifier
         :return: The formatted path
         """
-        return Path(self.base_path, JsonFileStorage.add_extension(resource_id))
+        filename = file.make_valid_filename(resource_id)
+        base_path = base_path if base_path else self.base_path
+        return Path(base_path, JsonFileFS.add_extension(filename))
 
     def _resource_id(self, resource_path: Path) -> str:
         """
@@ -171,4 +225,29 @@ class FileSystemStorage(Storage, JsonFileStorage):
         :param resource_path: The full path
         :return: The resource id
         """
-        return JsonFileStorage.get_just_filename(resource_path)
+        resource_id = file.revert_valid_filename(
+            JsonFileFS.get_just_filename(resource_path)
+        )
+        return resource_id
+
+    def _resource_group_path(
+        self, group_id: str, base_path: Optional[Path] = None
+    ) -> Path:
+        """
+        Gets the full path for a stored resource group (which will be translated into a folder).
+        :param group_id: The identifier of the resource group.
+        :return: The formatted path
+        """
+        folder_name = file.make_valid_filename(group_id)
+        base_path = base_path if base_path else self.base_path
+        return Path(base_path, folder_name)
+
+    def _resource_group_id(self, group_path: Path) -> str:
+        """
+        Gets the name of a resource group given a full filepath.
+        :param group_path: The full path
+        :return: The resource group id
+        """
+        folder_name = JsonFileFS.get_last_folder(group_path)
+        group_id = file.revert_valid_filename(folder_name)
+        return group_id

--- a/mlte/store/common/http_storage.py
+++ b/mlte/store/common/http_storage.py
@@ -88,7 +88,7 @@ class HttpStorage(Storage):
         resource_type: Optional[str] = None,
     ) -> Any:
         """
-        Sends an HTTP command request to the backend API, and returns a JSON response from it. Commonly not used direclty, as it is expected
+        Sends an HTTP command request to the backend API, and returns a JSON response from it. Commonly not used directly, as it is expected
         for callers to use the post(), put(), read() and delete() method, but can be used when a non-standard command, which does not properly
         match the arguments of the previous 4 methods, needs to be sent.
 

--- a/mlte/store/common/http_storage.py
+++ b/mlte/store/common/http_storage.py
@@ -1,28 +1,28 @@
 """
-mlte/store/catalog/common/http_store.py
-
 Base class for HTTP based stores.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from mlte.backend.core.config import settings
 from mlte.store.base import StoreURI
 from mlte.store.common.http_clients import OAuthHttpClient, RequestsClient
 from mlte.store.common.storage import Storage
+from mlte.user.model import MethodType, ResourceType
 
 API_PREFIX = settings.API_PREFIX
 """API URL prefix."""
 
 
 class HttpStorage(Storage):
-    """An HTTP base storage."""
+    """An HTTP base storage for a given resource type."""
 
     def __init__(
         self,
         uri: StoreURI,
+        resource_type: ResourceType,
         client: Optional[OAuthHttpClient] = None,
     ) -> None:
         super().__init__(uri)
@@ -37,6 +37,42 @@ class HttpStorage(Storage):
         self.clean_url = uri.uri
         """Store the clean URL without credentials."""
 
+        self.base_url = f"{self.clean_url}{API_PREFIX}/{resource_type.value}"
+        """Base resource URL."""
+
     def start_session(self):
-        # Authenticate.
+        """Perform authentication."""
         self.client.authenticate(f"{self.clean_url}{API_PREFIX}")
+
+    def post(self, resource_url: str, json: Any) -> Any:
+        """Post method, to create resource."""
+        return self.send_command(resource_url, MethodType.POST, json)
+
+    def put(self, resource_url: str, json: Any) -> Any:
+        """Put method, to update resource."""
+        return self.send_command(resource_url, MethodType.PUT, json)
+
+    def get(self, resource_url: str) -> Any:
+        """Get method, to read resource."""
+        return self.send_command(resource_url, MethodType.GET)
+
+    def delete(self, resource_url: str) -> Any:
+        """Delete method, to remove resource."""
+        return self.send_command(resource_url, MethodType.DELETE)
+
+    def send_command(
+        self, resource_url: str, method: MethodType, json: Optional[Any] = None
+    ):
+        url = f"{self.base_url}{resource_url}"
+        if method == MethodType.POST:
+            res = self.client.post(url, json=json)
+        elif method == MethodType.PUT:
+            res = self.client.put(url, json=json)
+        elif method == MethodType.GET:
+            res = self.client.get(url)
+        elif method == MethodType.DELETE:
+            res = self.client.delete(url)
+        else:
+            raise RuntimeError(f"Invalid method type: {method}")
+        self.client.raise_for_response(res)
+        return res.json()

--- a/mlte/store/custom_list/store_session.py
+++ b/mlte/store/custom_list/store_session.py
@@ -73,7 +73,9 @@ class CustomListEntryMapper(ResourceMapper):
     ) -> None:
         if list_name in CustomListParentMappings.parent_mappings.keys():
             if parent not in self.list(
-                CustomListParentMappings.parent_mappings[list_name]
+                CustomListName(
+                    CustomListParentMappings.parent_mappings[list_name]
+                )
             ):
                 raise errors.ErrorNotFound(
                     f"Parent {parent} does not exist in list {CustomListParentMappings.parent_mappings[list_name]}"
@@ -91,7 +93,7 @@ class CustomListEntryMapper(ResourceMapper):
             list_name
         )
         if child_list_name:
-            for child_entry_name in self.list(child_list_name):
+            for child_entry_name in self.list(CustomListName(child_list_name)):
                 child_entry = self.read(child_entry_name, child_list_name)
                 if child_entry.parent == entry_name:
                     self.delete(child_entry_name, child_list_name)

--- a/mlte/store/custom_list/underlying/fs.py
+++ b/mlte/store/custom_list/underlying/fs.py
@@ -72,6 +72,14 @@ class FileSystemCustomListEntryMapper(CustomListEntryMapper):
         self.storage = storage.clone()
         """A reference to underlying storage."""
 
+        # Create folders for existing CustomLists.
+        for custom_list_type in CustomListName:
+            try:
+                self.storage.create_resource_group(custom_list_type.value)
+            except FileExistsError:
+                # If it already existed, we just ignore warning.
+                pass
+
     def create(
         self,
         entry: CustomListEntryModel,

--- a/mlte/store/custom_list/underlying/fs.py
+++ b/mlte/store/custom_list/underlying/fs.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import List, Optional
 
-import mlte.store.error as errors
 from mlte.custom_list.custom_list_names import CustomListName
 from mlte.custom_list.model import CustomListEntryModel
 from mlte.store.base import StoreURI
@@ -79,68 +77,63 @@ class FileSystemCustomListEntryMapper(CustomListEntryMapper):
         entry: CustomListEntryModel,
         list_name: Optional[CustomListName] = None,
     ) -> CustomListEntryModel:
+        if list_name is None:
+            raise RuntimeError("Custom list name can't be None")
         self._ensure_parent_exists(entry.parent, list_name)
-        self._set_base_path(list_name)
-        self.storage.ensure_resource_does_not_exist(entry.name)
-        return self._write_entry(entry)
+        self.storage.ensure_resource_does_not_exist(
+            entry.name, [list_name.value]
+        )
+        return self._write_entry(entry, list_name)
 
     def read(
         self, entry_name: str, list_name: Optional[CustomListName] = None
     ) -> CustomListEntryModel:
-        self._set_base_path(list_name)
-        return self._read_entry(entry_name)
+        if list_name is None:
+            raise RuntimeError("Custom list name can't be None")
+        return self._read_entry(entry_name, list_name)
 
     def list(self, list_name: Optional[CustomListName] = None) -> List[str]:
-        self._set_base_path(list_name)
-        return self.storage.list_resources()
+        if list_name is None:
+            raise RuntimeError("Custom list name can't be None")
+        return self.storage.list_resources([list_name.value])
 
     def edit(
         self,
         entry: CustomListEntryModel,
         list_name: Optional[CustomListName] = None,
     ) -> CustomListEntryModel:
+        if list_name is None:
+            raise RuntimeError("Custom list name can't be None")
         self._ensure_parent_exists(entry.parent, list_name)
-        self._set_base_path(list_name)
-        self.storage.ensure_resource_exists(entry.name)
-        return self._write_entry(entry)
+        self.storage.ensure_resource_exists(entry.name, [list_name.value])
+        return self._write_entry(entry, list_name)
 
     def delete(
         self, entry_name: str, list_name: Optional[CustomListName] = None
     ) -> CustomListEntryModel:
-        self._set_base_path(list_name)
-        self.storage.ensure_resource_exists(entry_name)
-        entry = self._read_entry(entry_name)
+        if list_name is None:
+            raise RuntimeError("Custom list name can't be None")
+        self.storage.ensure_resource_exists(entry_name, [list_name.value])
+        entry = self._read_entry(entry_name, list_name)
         self._delete_children(list_name, entry_name)
 
-        self._set_base_path(list_name)
-        self.storage.delete_resource(entry_name)
+        self.storage.delete_resource(entry_name, [list_name.value])
         return entry
 
-    def _read_entry(self, entry_name: str) -> CustomListEntryModel:
+    def _read_entry(
+        self, entry_name: str, list_name: CustomListName
+    ) -> CustomListEntryModel:
         """Reads a custom list entry."""
-        self.storage.ensure_resource_exists(entry_name)
-        return CustomListEntryModel(**self.storage.read_resource(entry_name))
+        self.storage.ensure_resource_exists(entry_name, [list_name.value])
+        return CustomListEntryModel(
+            **self.storage.read_resource(entry_name, [list_name.value])
+        )
 
-    def _write_entry(self, entry: CustomListEntryModel) -> CustomListEntryModel:
+    def _write_entry(
+        self, entry: CustomListEntryModel, list_name: CustomListName
+    ) -> CustomListEntryModel:
         """Writes a custom list entry to storage."""
-        self.storage.write_resource(entry.name, entry.to_json())
-        return self._read_entry(entry.name)
-
-    def _set_base_path(self, list_name: Optional[CustomListName]) -> None:
-        """
-        Sets the path to the list specified in the param and checks list exists.
-
-        This method sets the base path of the mapper to the path of the list given as a param.
-        This has to happen before each request to ensure that the operation happens on the correct list.
-        """
-        if (
-            list_name is None
-            or list_name not in CustomListName._value2member_map_
-        ):
-            raise errors.ErrorNotFound(
-                f"CustomListName, {list_name}, does not exist or is None."
-            )
-        else:
-            self.storage.setup_base_path(
-                Path(self.storage.sub_folder, str(list_name))
-            )
+        self.storage.write_resource(
+            entry.name, entry.to_json(), [list_name.value]
+        )
+        return self._read_entry(entry.name, list_name)

--- a/mlte/store/custom_list/underlying/fs.py
+++ b/mlte/store/custom_list/underlying/fs.py
@@ -141,6 +141,6 @@ class FileSystemCustomListEntryMapper(CustomListEntryMapper):
                 f"CustomListName, {list_name}, does not exist or is None."
             )
         else:
-            self.storage.set_base_path(
+            self.storage.setup_base_path(
                 Path(self.storage.sub_folder, str(list_name))
             )

--- a/mlte/store/user/underlying/fs.py
+++ b/mlte/store/user/underlying/fs.py
@@ -99,7 +99,7 @@ class FileSystemUserMappper(UserMapper):
         self.group_mapper = group_mapper
         """Reference to group mapper, to get updated groups when needed."""
 
-        self.storage.set_base_path(
+        self.storage.setup_base_path(
             Path(FileSystemUserStore.BASE_USERS_FOLDER, self.USERS_FOLDER)
         )
         """Set the subfolder for this resource."""
@@ -178,7 +178,7 @@ class FileSystemGroupMappper(GroupMapper):
         self.storage = storage.clone()
         """A reference to underlying storage."""
 
-        self.storage.set_base_path(
+        self.storage.setup_base_path(
             Path(FileSystemUserStore.BASE_USERS_FOLDER, self.GROUPS_FOLDER)
         )
         """Set the subfolder for this resource."""
@@ -233,7 +233,7 @@ class FileSystemPermissionMappper(PermissionMapper):
         self.storage = storage.clone()
         """A reference to underlying storage."""
 
-        self.storage.set_base_path(
+        self.storage.setup_base_path(
             Path(FileSystemUserStore.BASE_USERS_FOLDER, self.PERMISSIONS_FOLDER)
         )
         """Set the subfolder for this resource."""

--- a/test/_private/test_text.py
+++ b/test/_private/test_text.py
@@ -1,0 +1,39 @@
+"""
+Unit test for the text util module.
+"""
+
+import pytest
+
+from mlte._private import text
+
+
+@pytest.mark.parametrize(
+    "string,replacements,revert,expected",
+    [
+        ("no_invalid_chars", {"/": "-", "*": ":"}, False, "no_invalid_chars"),
+        (
+            "two_invalid/chars*",
+            {"/": "-", "*": ":"},
+            False,
+            "two_invalid-chars:",
+        ),
+        (
+            "longer_substrings//chars***oo",
+            {"//": "-", "***": ":-"},
+            False,
+            "longer_substrings-chars:-oo",
+        ),
+        (
+            "two_invalid-chars:",
+            {"/": "-", "*": ":"},
+            True,
+            "two_invalid/chars*",
+        ),
+    ],
+)
+def test_replace_all(
+    string: str, replacements: dict[str, str], revert: bool, expected: str
+):
+    """Test that replacement works as expected."""
+    replaced = text.replace_all(string, replacements, revert)
+    assert replaced == expected

--- a/test/backend/fixture/http.py
+++ b/test/backend/fixture/http.py
@@ -23,7 +23,10 @@ from test.store.catalog.fixture import TEST_CATALOG_ID
 def mem_store_test_api() -> Callable[[Optional[UserWithPassword]], TestAPI]:
     """Sets up a memory-based test API and returns it."""
 
-    def wrapper(api_user: Optional[UserWithPassword] = None) -> TestAPI:
-        return TestAPI(user=api_user, default_catalog_id=TEST_CATALOG_ID)
+    def wrapper(
+        api_user: Optional[UserWithPassword] = None,
+        default_catalog_id: str = TEST_CATALOG_ID,
+    ) -> TestAPI:
+        return TestAPI(user=api_user, default_catalog_id=default_catalog_id)
 
     return wrapper

--- a/test/store/artifact/test_underlying.py
+++ b/test/store/artifact/test_underlying.py
@@ -364,3 +364,24 @@ def test_artifact_overwrite(
 
         # Attempt to write with `force` succeeds
         _ = handle.write_artifact(model_id, version_id, artifact, force=True)
+
+
+@pytest.mark.parametrize("store_fixture_name", artifact_stores())
+def test_invalid_chars(
+    store_fixture_name: str, request: pytest.FixtureRequest
+) -> None:
+    """Test creation with chars that may be invalid in some storage types."""
+    store: ArtifactStore = request.getfixturevalue(store_fixture_name)
+
+    model_id = "model/test"
+    version_id = "version/test"
+    artifact_id = "myid/test"
+    user = TEST_API_USERNAME
+
+    with ManagedArtifactSession(store.session()) as handle:
+        handle.create_model(Model(identifier=model_id))
+        handle.create_version(model_id, Version(identifier=version_id))
+        artifact = ArtifactFactory.make(ArtifactType.REPORT, artifact_id)
+        handle.write_artifact_with_header(
+            model_id, version_id, artifact, user=user
+        )

--- a/test/store/artifact/test_underlying.py
+++ b/test/store/artifact/test_underlying.py
@@ -321,6 +321,7 @@ def test_artifact_parents(
         # The artifact is present
         read = handle.read_artifacts(model_id, version_id)
         assert len(read) == 1
+        handle.read_artifact(model_id, version_id, artifact_id)
 
 
 @pytest.mark.parametrize(
@@ -372,10 +373,6 @@ def test_invalid_chars(
 ) -> None:
     """Test creation with chars that may be invalid in some storage types."""
     store: ArtifactStore = request.getfixturevalue(store_fixture_name)
-
-    # TODO: Ignore this case for now, URL's are not well encoded.
-    if store_fixture_name == "http_store":
-        return
 
     model_id = "model/test"
     version_id = "version/test"

--- a/test/store/artifact/test_underlying.py
+++ b/test/store/artifact/test_underlying.py
@@ -373,6 +373,10 @@ def test_invalid_chars(
     """Test creation with chars that may be invalid in some storage types."""
     store: ArtifactStore = request.getfixturevalue(store_fixture_name)
 
+    # TODO: Ignore this case for now, URL's are not well encoded.
+    if store_fixture_name == "http_store":
+        return
+
     model_id = "model/test"
     version_id = "version/test"
     artifact_id = "myid/test"

--- a/test/store/catalog/fixture.py
+++ b/test/store/catalog/fixture.py
@@ -74,9 +74,11 @@ def create_api_and_http_store(
 
 
 @pytest.fixture(scope="function")
-def create_test_store(tmpdir_factory) -> typing.Callable[[str], CatalogStore]:
+def create_test_store(
+    tmpdir_factory, test_catalog_id: str = TEST_CATALOG_ID
+) -> typing.Callable[[str], CatalogStore]:
     def _make(
-        store_fixture_name, catalog_id: str = TEST_CATALOG_ID
+        store_fixture_name, catalog_id: str = test_catalog_id
     ) -> CatalogStore:
         if store_fixture_name == StoreType.LOCAL_MEMORY.value:
             return create_memory_store()


### PR DESCRIPTION
Addresses #613 and #617 by allowing models, versions, artifacts, catalogs and catalog entries to have "/" in their names. 

 - This was done by doing a substantial refactoring of the common FS and HTTP Storage features, moving all file/url-specific parts into this common layer, and letting the artifact, catalog and customlist implementations be lighter by using this common layer instead. With this refactoring, it was possible to centralize and handle this type of invalid characters.
 - Note that changes were needed in API endpoints that may receive data from HTTP store implementations, to decode the "/" char (standard url quote/unquote do not work well with how FastAPI automatically translates this and handles routing of paths, even with the :path label in endpoint route param names). This is implemented for current endpoints, but new ones will have to remember to call to decode chars if they want to support them in each method that receives them. Note that to test this through a REST API client, the person would have to manually encode these chars as well.