### PR TITLE
Feature/frontend-qas-link

### DIFF
--- a/demo/sample_store/models/OxfordFlower/0.0.1/default.negotiation_card.json
+++ b/demo/sample_store/models/OxfordFlower/0.0.1/default.negotiation_card.json
@@ -201,7 +201,7 @@
             "system_requirements": [
                 {
                     "identifier": "qas_id_001",
-                    "quality": "Fairness: Model Impartial to Photo Location",
+                    "quality": "Model Impartial to Photo Location",
                     "stimulus": "The model receives a picture taken at the garden",
                     "source": "the flower identification application",
                     "environment": "normal operations",
@@ -210,7 +210,7 @@
                 },
                 {
                     "identifier": "qas_id_002",
-                    "quality": "Robustness: Model Robust to Noise (Image Blur)",
+                    "quality": "Model Robust to Noise (Image Blur)",
                     "stimulus": "The model receives a picture taken at the garden, and it is a bit blurry,",
                     "source": "the flower identification application",
                     "environment": "normal operations",
@@ -219,7 +219,7 @@
                 },
                 {
                     "identifier": "qas_id_003",
-                    "quality": "Robustness: Model Robust to Noise (Channel Loss)",
+                    "quality": "Model Robust to Noise (Channel Loss)",
                     "stimulus": "The model receives a picture taken at the garden",
                     "source": "the flower identification application running on a loaned device ",
                     "environment": "normal operations. These devices are known to sometimes lose a channel (i.e., RGB channel)",
@@ -228,7 +228,7 @@
                 },
                 {
                     "identifier": "qas_id_004",
-                    "quality": "Performance: Resource Consumption on Operational Platform",
+                    "quality": "Resource Consumption on Operational Platform",
                     "stimulus": "The model running on the loaned device receives pictures taken at the garden",
                     "source": "the flower identification application",
                     "environment": "normal operations. The loaned devices are small, inexpensive devices with limited CPU power, as well as limited memory and disk space (512 MB and 150 MB, respectively)",
@@ -237,7 +237,7 @@
                 },
                 {
                     "identifier": "qas_id_005",
-                    "quality": "Interpretability: Understanding Model Results",
+                    "quality": "Understanding Model Results",
                     "stimulus": "The model receives a picture taken at the garden",
                     "source": "the flower identification application",
                     "environment": "normal operations",
@@ -246,7 +246,7 @@
                 },
                 {
                     "identifier": "qas_id_006",
-                    "quality": "Functional Correctness: Accuracy",
+                    "quality": "Accuracy",
                     "stimulus": "The model receives a picture taken at the garden",
                     "source": "flower identification application",
                     "environment": "normal operations",
@@ -255,7 +255,7 @@
                 },
                 {
                     "identifier": "qas_id_007",
-                    "quality": "Functional Correctness: Input and Output Specification",
+                    "quality": "Input and Output Specification",
                     "stimulus": "The model receives a picture taken at the garden",
                     "source": "flower identification application",
                     "environment": "normal operations",
@@ -264,7 +264,7 @@
                 },
                 {
                     "identifier": "qas_id_008",
-                    "quality": "Resilience: Input Validation",
+                    "quality": "Input Validation",
                     "stimulus": "The ML pipeline receives a picture taken at the garden that does not conform to the input specification",
                     "source": "the flower identification application",
                     "environment": "normal operations",
@@ -273,7 +273,7 @@
                 },
                 {
                     "identifier": "qas_id_009",
-                    "quality": "Monitorability: Detect Out-of-Distribution (OOD) Inputs",
+                    "quality": "Detect Out-of-Distribution (OOD) Inputs",
                     "stimulus": "The ML pipeline receives a picture that corresponds to an OOD input",
                     "source": "the flower identification application",
                     "environment": "normal operations",
@@ -282,7 +282,7 @@
                 },
                 {
                     "identifier": "qas_id_010",
-                    "quality": "Monitorability: Detect Shifts in Output (Confidence) Distribution",
+                    "quality": "Detect Shifts in Output (Confidence) Distribution",
                     "stimulus": "The ML pipeline detects an output distribution change",
                     "source": "the output produced by the model",
                     "environment": "normal operations",
@@ -291,7 +291,7 @@
                 },
                 {
                     "identifier": "qas_id_011",
-                    "quality": "Performance: Inference Time on Operational Platform",
+                    "quality": "Inference Time on Operational Platform",
                     "stimulus": "Model running on the loaned device receives a picture",
                     "source": "the flower identification application",
                     "environment": "normal operations",

--- a/mlte/frontend/nuxt-app/components/Admin/group-edit.vue
+++ b/mlte/frontend/nuxt-app/components/Admin/group-edit.vue
@@ -49,7 +49,7 @@
 const config = useRuntimeConfig();
 const token = useCookie("token");
 
-const emit = defineEmits(["cancel", "submit"]);
+const emits = defineEmits(["cancel", "submit"]);
 const props = defineProps({
   modelValue: {
     type: Object,

--- a/mlte/frontend/nuxt-app/components/Admin/group-list.vue
+++ b/mlte/frontend/nuxt-app/components/Admin/group-list.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(["addGroup", "editGroup", "deleteGroup"]);
+const emits = defineEmits(["addGroup", "editGroup", "deleteGroup"]);
 const props = defineProps({
   modelValue: {
     type: Array,

--- a/mlte/frontend/nuxt-app/components/Admin/user-edit.vue
+++ b/mlte/frontend/nuxt-app/components/Admin/user-edit.vue
@@ -107,7 +107,7 @@
 const config = useRuntimeConfig();
 const token = useCookie("token");
 
-const emit = defineEmits(["cancel", "submit", "updateUserGroups"]);
+const emits = defineEmits(["cancel", "submit", "updateUserGroups"]);
 const props = defineProps({
   modelValue: {
     type: Object,

--- a/mlte/frontend/nuxt-app/components/Admin/user-list.vue
+++ b/mlte/frontend/nuxt-app/components/Admin/user-list.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(["addUser", "editUser", "deleteUser"]);
+const emits = defineEmits(["addUser", "editUser", "deleteUser"]);
 const props = defineProps({
   modelValue: {
     type: Array,

--- a/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
@@ -105,14 +105,15 @@ if (QAapiOptions.value) {
 // On load, populate parent QA Category field if a qualiity attribute is selected
 if (props.initialQualityAttribute) {
   QAapiOptions.value?.forEach((attribute: object) => {
-    if (attribute.value === props.initialQualityAttribute) {
+    if (attribute.name === props.initialQualityAttribute) {
       qaCategory.value = attribute.parent;
+      categoryChange(qaCategory.value, props.initialQualityAttribute);
     }
   });
 }
 
-// newAttribute is used on startup to set the value of category and parent
-function categoryChange(newCategory: string) {
+// initialAttribute is used on startup to set the value of category and parent
+function categoryChange(newCategory: string, initialAttrbute?: string) {
   selectedQAOptions.value = [];
   AllQAOptions.value.forEach((attribute: object) => {
     if (attribute.parent === newCategory) {
@@ -120,6 +121,11 @@ function categoryChange(newCategory: string) {
     }
   });
 
-  emit("updateAttribute", "");
+  if(initialAttrbute === undefined){
+    emit("updateAttribute", "");
+  }
+  else{
+    emit("updateAttribute", initialAttrbute)
+  }
 }
 </script>

--- a/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
@@ -1,0 +1,125 @@
+<template>
+  <div>
+    <UsaSelect
+      v-model="qaCategory"
+      :options="QACategoryOptions"
+      @change="categoryChange(qaCategory)"
+    >
+      <template #label>
+        <slot />
+      </template>
+      <template #error-message>Not defined</template>
+    </UsaSelect>
+
+    <UsaSelect
+      v-model="qualityAttribute"
+      :options="selectedQAOptions"
+      @change="$emit('updateAttribute', $event.target.value)"
+    >
+      <template #label>
+        Quality Attribute
+        <InfoIcon>
+          More specific quality attribute that the test example is validating,
+          e.g., accuracy, inference time, robustness to image blur.
+        </InfoIcon>
+      </template>
+      <template #error-message>Not defined</template>
+    </UsaSelect>
+  </div>
+</template>
+
+<script setup lang="ts">
+const config = useRuntimeConfig();
+const token = useCookie("token");
+
+const emit = defineEmits(["updateAttribute"]);
+
+const props = defineProps({
+  initialQualityAttribute: {
+    type: String,
+    required: true,
+    default: "",
+  },
+});
+
+const qaCategory = ref("");
+const qualityAttribute = ref(props.initialQualityAttribute);
+
+const QACategoryOptions = ref<
+  {
+    value: string;
+    text: string;
+    description: string;
+    parent: string;
+  }[]
+>([]);
+const { data: QACategoryAPIData } = await useFetch<string[]>(
+  config.public.apiPath + "/custom_list/qa_categories/",
+  {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer " + token.value,
+    },
+  },
+);
+if (QACategoryAPIData.value) {
+  QACategoryAPIData.value.forEach((category: object) => {
+    QACategoryOptions.value.push({
+      value: category.name,
+      text: category.name,
+      description: category.description,
+      parent: category.parent,
+    });
+  });
+}
+
+const selectedQAOptions = ref([]);
+const AllQAOptions = ref<
+  {
+    value: string;
+    text: string;
+    description: string;
+    parent: string;
+  }[]
+>([]);
+const { data: QAapiOptions } = await useFetch<string[]>(
+  config.public.apiPath + "/custom_list/quality_attributes/",
+  {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer " + token.value,
+    },
+  },
+);
+if (QAapiOptions.value) {
+  QAapiOptions.value.forEach((attribute: object) => {
+    AllQAOptions.value.push({
+      value: attribute.name,
+      text: attribute.name,
+      description: attribute.description,
+      parent: attribute.parent,
+    });
+  });
+}
+
+// On load, populate parent QA Category field if a qualiity attribute is selected
+if (props.initialQualityAttribute) {
+  QAapiOptions.value?.forEach((attribute: object) => {
+    if (attribute.value === props.initialQualityAttribute) {
+      qaCategory.value = attribute.parent;
+    }
+  });
+}
+
+// newAttribute is used on startup to set the value of category and parent
+function categoryChange(newCategory: string) {
+  selectedQAOptions.value = [];
+  AllQAOptions.value.forEach((attribute: object) => {
+    if (attribute.parent === newCategory) {
+      selectedQAOptions.value.push(attribute);
+    }
+  });
+
+  emit("updateAttribute", "");
+}
+</script>

--- a/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
@@ -35,25 +35,22 @@
         {{ requirement.measure }}.
       </p>
 
-      <UsaSelect
-        v-model="requirement.quality"
-        :options="QACategoryOptions"
+      <FormFieldsQualityAttributes
+        @update-attribute="requirement.quality = $event"
       >
-        <template #label>
-          <b>System Quality:</b> What is the model quality attribute category to be tested, such
-          as accuracy, performance, robustness, fairness, or resource
-          consumption?
-          <InfoIcon>
-            Quality attribute category by which the model will be evaluated in the context of the
-            system <br />
-            (e.g., Accuracy, Performance, Robustness, Fairness, Resource
-            Consumption).
-            <br />
-            <br />
-            <i>Example: Response time.</i>
-          </InfoIcon>
-        </template>
-      </UsaSelect>
+        <b>System Quality:</b> What is the model quality attribute category to be tested, such
+        as accuracy, performance, robustness, fairness, or resource
+        consumption?
+        <InfoIcon>
+          Quality attribute category by which the model will be evaluated in the context of the
+          system <br />
+          (e.g., Accuracy, Performance, Robustness, Fairness, Resource
+          Consumption).
+          <br />
+          <br />
+          <i>Example: Response time.</i>
+        </InfoIcon>
+      </FormFieldsQualityAttributes>
 
       <UsaTextInput v-model="requirement.stimulus">
         <template #label>

--- a/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
@@ -151,9 +151,6 @@
 </template>
 
 <script setup lang="ts">
-const config = useRuntimeConfig();
-const token = useCookie("token");
-
 const props = defineProps({
   modelValue: {
     type: Array,
@@ -219,34 +216,6 @@ const systemModalRows = ref([
     measure: "No errors due to unavailable resources",
   },
 ]);
-
-const QACategoryOptions = ref<
-  {
-    value: string;
-    text: string;
-    description: string;
-    parent: string;
-  }[]
->([]);
-const { data: QACategoryAPIData } = await useFetch<string[]>(
-  config.public.apiPath + "/custom_list/qa_categories/",
-  {
-    method: "GET",
-    headers: {
-      Authorization: "Bearer " + token.value,
-    },
-  },
-);
-if (QACategoryAPIData.value) {
-  QACategoryAPIData.value.forEach((category: object) => {
-    QACategoryOptions.value.push({
-      value: category.name,
-      text: category.name,
-      description: category.description,
-      parent: category.parent,
-    });
-  });
-}
 
 function addRequirement() {
   props.modelValue.push({

--- a/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
@@ -34,7 +34,11 @@
         {{ requirement.environment }}. {{ requirement.response }}
         {{ requirement.measure }}.
       </p>
-      <UsaTextInput v-model="requirement.quality">
+
+      <UsaSelect
+        v-model="requirement.quality"
+        :options="QACategoryOptions"
+      >
         <template #label>
           <b>System Quality:</b> What is the model quality attribute category to be tested, such
           as accuracy, performance, robustness, fairness, or resource
@@ -49,7 +53,7 @@
             <i>Example: Response time.</i>
           </InfoIcon>
         </template>
-      </UsaTextInput>
+      </UsaSelect>
 
       <UsaTextInput v-model="requirement.stimulus">
         <template #label>
@@ -149,6 +153,9 @@
 </template>
 
 <script setup lang="ts">
+const config = useRuntimeConfig();
+const token = useCookie("token");
+
 const props = defineProps({
   modelValue: {
     type: Array,
@@ -214,6 +221,34 @@ const systemModalRows = ref([
     measure: "No errors due to unavailable resources",
   },
 ]);
+
+const QACategoryOptions = ref<
+  {
+    value: string;
+    text: string;
+    description: string;
+    parent: string;
+  }[]
+>([]);
+const { data: QACategoryAPIData } = await useFetch<string[]>(
+  config.public.apiPath + "/custom_list/qa_categories/",
+  {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer " + token.value,
+    },
+  },
+)
+if (QACategoryAPIData.value) {
+  QACategoryAPIData.value.forEach((category: object) => {
+    QACategoryOptions.value.push({
+      value: category.name,
+      text: category.name,
+      description: category.description,
+      parent: category.parent,
+    })
+  })
+}
 
 function addRequirement() {
   props.modelValue.push({

--- a/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
@@ -252,7 +252,7 @@ if (QACategoryAPIData.value) {
 
 function addRequirement() {
   props.modelValue.push({
-    quality: "<System Quality>",
+    quality: "",
     stimulus: "<Stimulus>",
     source: "<Source>",
     environment: "<Environment>",

--- a/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/system-requirements.vue
@@ -36,14 +36,15 @@
       </p>
 
       <FormFieldsQualityAttributes
+        :initial-quality-attribute="requirement.quality"
         @update-attribute="requirement.quality = $event"
       >
-        <b>System Quality:</b> What is the model quality attribute category to be tested, such
-        as accuracy, performance, robustness, fairness, or resource
-        consumption?
+        <b>System Quality:</b> What is the model quality attribute category to
+        be tested, such as accuracy, performance, robustness, fairness, or
+        resource consumption?
         <InfoIcon>
-          Quality attribute category by which the model will be evaluated in the context of the
-          system <br />
+          Quality attribute category by which the model will be evaluated in the
+          context of the system <br />
           (e.g., Accuracy, Performance, Robustness, Fairness, Resource
           Consumption).
           <br />
@@ -55,8 +56,8 @@
       <UsaTextInput v-model="requirement.stimulus">
         <template #label>
           <b>Stimulus:</b> What is the input to the model, the action, or the
-          event that will enable testing of the quality attribute category, such as input data,
-          system event, or user operation?
+          event that will enable testing of the quality attribute category, such
+          as input data, system event, or user operation?
           <InfoIcon>
             A condition arriving at the system/model (e.g., data,
             <br />
@@ -235,7 +236,7 @@ const { data: QACategoryAPIData } = await useFetch<string[]>(
       Authorization: "Bearer " + token.value,
     },
   },
-)
+);
 if (QACategoryAPIData.value) {
   QACategoryAPIData.value.forEach((category: object) => {
     QACategoryOptions.value.push({
@@ -243,8 +244,8 @@ if (QACategoryAPIData.value) {
       text: category.name,
       description: category.description,
       parent: category.parent,
-    })
-  })
+    });
+  });
 }
 
 function addRequirement() {

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
@@ -54,34 +54,16 @@
       </span>
     </div>
 
-    <UsaSelect
-      v-model="modelValue.qa_category"
-      :options="QACategoryOptions"
-      @change="categoryChange(modelValue.qa_category)"
+    <FormFieldsQualityAttributes
+      @update-category="props.modelValue.qa_category = $event"
+      @update-attribute="props.modelValue.quality_attribute = $event"
     >
-      <template #label>
-        Quality Attribute Category
-        <InfoIcon>
-          High-level quality attribute category that the test example is 
-          validating, e.g., functional correctness, performance, robustness.
-        </InfoIcon>
-      </template>
-      <template #error-message>Not defined</template>
-    </UsaSelect>
-
-    <UsaSelect
-      v-model="modelValue.quality_attribute"
-      :options="selectedQAOptions"
-    >
-      <template #label>
-        Quality Attribute
-        <InfoIcon>
-          More specific quality attribute that the test example is validating, e.g.,
-          accuracy, inference time, robustness to image blur.
-        </InfoIcon>
-      </template>
-      <template #error-message>Not defined</template>
-    </UsaSelect>
+      Quality Attribute Category
+      <InfoIcon>
+        High-level quality attribute category that the test example is 
+        validating, e.g., functional correctness, performance, robustness.
+      </InfoIcon>
+    </FormFieldsQualityAttributes>
 
     <UsaSelect
       v-model="modelValue.code_type"
@@ -151,7 +133,7 @@
 const config = useRuntimeConfig();
 const token = useCookie("token");
 
-const emit = defineEmits(["cancel", "submit", "updateEntry"]);
+const emits = defineEmits(["cancel", "submit", "updateEntry"]);
 const props = defineProps({
   modelValue: {
     type: Object,
@@ -234,63 +216,6 @@ const tagOptions = ref([
   { name: "Time Series", selected: false },
 ]);
 
-const QACategoryOptions = ref<
-  {
-    value: string;
-    text: string;
-    description: string;
-    parent: string;
-  }[]
->([]);
-const { data: QACategoryAPIData } = await useFetch<string[]>(
-  config.public.apiPath + "/custom_list/qa_categories/",
-  {
-    method: "GET",
-    headers: {
-      Authorization: "Bearer " + token.value,
-    },
-  },
-)
-if (QACategoryAPIData.value) {
-  QACategoryAPIData.value.forEach((category: object) => {
-    QACategoryOptions.value.push({
-      value: category.name,
-      text: category.name,
-      description: category.description,
-      parent: category.parent,
-    })
-  })
-}
-
-const selectedQAOptions = ref([]);
-const AllQAOptions = ref<
-  {
-    value: string;
-    text: string;
-    description: string;
-    parent: string;
-  }[]
->([]);
-const { data: QAapiOptions } = await useFetch<string[]>(
-  config.public.apiPath + "/custom_list/quality_attributes/",
-  {
-    method: "GET",
-    headers: {
-      Authorization: "Bearer " + token.value,
-    },
-  },
-)
-if (QAapiOptions.value) {
-  QAapiOptions.value.forEach((attribute: object) => {
-    AllQAOptions.value.push({
-      value: attribute.name,
-      text: attribute.name,
-      description: attribute.description,
-      parent: attribute.parent,
-    })
-  })
-}
-
 const codeTypeOptions = ref([
   { value: "measurement", text: "Measurement" },
   { value: "validation", text: "Validation " },
@@ -301,9 +226,6 @@ tagOptions.value.forEach((tagOption: object) => {
     tagOption.selected = true;
   }
 });
-
-// On page load, populate Quality Attribute field if one is selected
-categoryChange(props.modelValue.qa_category, props.modelValue.quality_attribute)
 
 async function submit() {
   formErrors.value = resetFormErrors(formErrors.value);
@@ -342,22 +264,6 @@ function tagChange(selected: boolean, tagOption: object) {
     );
     const index = props.modelValue.tags.indexOf(objForRemoval);
     props.modelValue.tags.splice(index, 1);
-  }
-}
-
-function categoryChange(newCategory: string, quality_attribute?: string){
-  selectedQAOptions.value = []
-  AllQAOptions.value.forEach((attribute: object) => {
-    if (attribute.parent == newCategory){
-      selectedQAOptions.value.push(attribute)
-    }
-  })
-
-  if (typeof quality_attribute == 'undefined'){
-    props.modelValue.quality_attribute = ""
-  }
-  else{
-    props.modelValue.quality_attribute = quality_attribute
   }
 }
 

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
@@ -60,7 +60,7 @@
     >
       Quality Attribute Category
       <InfoIcon>
-        High-level quality attribute category that the test example is 
+        High-level quality attribute category that the test example is
         validating, e.g., functional correctness, performance, robustness.
       </InfoIcon>
     </FormFieldsQualityAttributes>

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
@@ -54,6 +54,7 @@
       </span>
     </div>
 
+    <!-- Delete when test catalog no longer saves qa category -->
     <UsaSelect
       v-model="modelValue.qa_category"
       :options="QACategoryOptions"
@@ -82,6 +83,19 @@
       </template>
       <template #error-message>Not defined</template>
     </UsaSelect>
+    <!-- End of delete section -->
+
+    <!-- Add back when test catalog no longer saves qa category -->
+    <!-- <FormFieldsQualityAttributes
+       @update-category="props.modelValue.qa_category = $event"
+       @update-attribute="props.modelValue.quality_attribute = $event"
+     >
+      Quality Attribute Category
+      <InfoIcon>
+        High-level quality attribute category that the test example is 
+        validating, e.g., functional correctness, performance, robustness.
+      </InfoIcon>
+     </FormFieldsQualityAttributes> -->
 
     <UsaSelect
       v-model="modelValue.code_type"
@@ -216,6 +230,7 @@ if (catalogList.value) {
   });
 }
 
+// Delete when test catalog no longer saves qa category
 const QACategoryOptions = ref<
   {
     value: string;
@@ -272,6 +287,7 @@ if (QAapiOptions.value) {
     });
   });
 }
+// End of delete section
 
 const tagOptions = ref([
   { name: "Audio Analysis", selected: false },
@@ -302,11 +318,13 @@ tagOptions.value.forEach((tagOption: object) => {
   }
 });
 
+// Delete when test catalog no longer saves qa category
 // On page load, populate Quality Attribute field if one is selected
 categoryChange(
   props.modelValue.qa_category,
   props.modelValue.quality_attribute,
 );
+// End of delete section
 
 async function submit() {
   formErrors.value = resetFormErrors(formErrors.value);
@@ -347,7 +365,7 @@ function tagChange(selected: boolean, tagOption: object) {
     props.modelValue.tags.splice(index, 1);
   }
 }
-
+// Delete when test catalog no longer saves qa category
 function categoryChange(newCategory: string, quality_attribute?: string) {
   selectedQAOptions.value = [];
   AllQAOptions.value.forEach((attribute: object) => {
@@ -362,6 +380,7 @@ function categoryChange(newCategory: string, quality_attribute?: string) {
     props.modelValue.quality_attribute = quality_attribute;
   }
 }
+// End of delete section
 
 function copyCode() {
   navigator.clipboard.writeText(props.modelValue.code);

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
@@ -54,16 +54,34 @@
       </span>
     </div>
 
-    <FormFieldsQualityAttributes
-      @update-category="props.modelValue.qa_category = $event"
-      @update-attribute="props.modelValue.quality_attribute = $event"
+    <UsaSelect
+      v-model="modelValue.qa_category"
+      :options="QACategoryOptions"
+      @change="categoryChange(modelValue.qa_category)"
     >
-      Quality Attribute Category
-      <InfoIcon>
-        High-level quality attribute category that the test example is
-        validating, e.g., functional correctness, performance, robustness.
-      </InfoIcon>
-    </FormFieldsQualityAttributes>
+      <template #label>
+        Quality Attribute Category
+        <InfoIcon>
+          High-level quality attribute category that the test example is
+          validating, e.g., functional correctness, performance, robustness.
+        </InfoIcon>
+      </template>
+      <template #error-message>Not defined</template>
+    </UsaSelect>
+
+    <UsaSelect
+      v-model="modelValue.quality_attribute"
+      :options="selectedQAOptions"
+    >
+      <template #label>
+        Quality Attribute
+        <InfoIcon>
+          More specific quality attribute that the test example is validating,
+          e.g., accuracy, inference time, robustness to image blur.
+        </InfoIcon>
+      </template>
+      <template #error-message>Not defined</template>
+    </UsaSelect>
 
     <UsaSelect
       v-model="modelValue.code_type"
@@ -198,6 +216,63 @@ if (catalogList.value) {
   });
 }
 
+const QACategoryOptions = ref<
+  {
+    value: string;
+    text: string;
+    description: string;
+    parent: string;
+  }[]
+>([]);
+const { data: QACategoryAPIData } = await useFetch<string[]>(
+  config.public.apiPath + "/custom_list/qa_categories/",
+  {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer " + token.value,
+    },
+  },
+);
+if (QACategoryAPIData.value) {
+  QACategoryAPIData.value.forEach((category: object) => {
+    QACategoryOptions.value.push({
+      value: category.name,
+      text: category.name,
+      description: category.description,
+      parent: category.parent,
+    });
+  });
+}
+
+const selectedQAOptions = ref([]);
+const AllQAOptions = ref<
+  {
+    value: string;
+    text: string;
+    description: string;
+    parent: string;
+  }[]
+>([]);
+const { data: QAapiOptions } = await useFetch<string[]>(
+  config.public.apiPath + "/custom_list/quality_attributes/",
+  {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer " + token.value,
+    },
+  },
+);
+if (QAapiOptions.value) {
+  QAapiOptions.value.forEach((attribute: object) => {
+    AllQAOptions.value.push({
+      value: attribute.name,
+      text: attribute.name,
+      description: attribute.description,
+      parent: attribute.parent,
+    });
+  });
+}
+
 const tagOptions = ref([
   { name: "Audio Analysis", selected: false },
   { name: "Classification", selected: false },
@@ -226,6 +301,12 @@ tagOptions.value.forEach((tagOption: object) => {
     tagOption.selected = true;
   }
 });
+
+// On page load, populate Quality Attribute field if one is selected
+categoryChange(
+  props.modelValue.qa_category,
+  props.modelValue.quality_attribute,
+);
 
 async function submit() {
   formErrors.value = resetFormErrors(formErrors.value);
@@ -264,6 +345,21 @@ function tagChange(selected: boolean, tagOption: object) {
     );
     const index = props.modelValue.tags.indexOf(objForRemoval);
     props.modelValue.tags.splice(index, 1);
+  }
+}
+
+function categoryChange(newCategory: string, quality_attribute?: string) {
+  selectedQAOptions.value = [];
+  AllQAOptions.value.forEach((attribute: object) => {
+    if (attribute.parent == newCategory) {
+      selectedQAOptions.value.push(attribute);
+    }
+  });
+
+  if (typeof quality_attribute === "undefined") {
+    props.modelValue.quality_attribute = "";
+  } else {
+    props.modelValue.quality_attribute = quality_attribute;
   }
 }
 

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-list.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-list.vue
@@ -5,7 +5,9 @@
         <th data-sortable scope="col" role="columnheader">Identifier</th>
         <th data-sortable scope="col" role="columnheader">Catalog</th>
         <th data-sortable scope="col" role="columnheader">Tags</th>
-        <th data-sortable scope="col" role="columnheader">Quality Attribute Category</th>
+        <th data-sortable scope="col" role="columnheader">
+          Quality Attribute Category
+        </th>
         <th data-sortable scope="col" role="columnheader">Code Type</th>
         <th data-sortable scope="col" role="columnheader">Actions</th>
       </tr>
@@ -51,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits(["addEntry", "editEntry", "deleteEntry"]);
+const emits = defineEmits(["addEntry", "editEntry", "deleteEntry"]);
 const props = defineProps({
   modelValue: {
     type: Array,

--- a/mlte/frontend/nuxt-app/composables/auth.ts
+++ b/mlte/frontend/nuxt-app/composables/auth.ts
@@ -1,7 +1,7 @@
 export function confirmLogout() {
   const token = useCookie("token");
   const user = useCookie("user");
-  const userRole = useCookie("userRole")
+  const userRole = useCookie("userRole");
   if (
     confirm("Are you sure you want to logout? All unsaved changes wll be lost.")
   ) {

--- a/mlte/frontend/nuxt-app/composables/form-methods.ts
+++ b/mlte/frontend/nuxt-app/composables/form-methods.ts
@@ -25,7 +25,7 @@ export function loadFindings(proxyObject: object) {
   // TODO(Kyle): Standardize conversion of proxy objects.
   const test_results = JSON.parse(JSON.stringify(proxyObject));
   const results = test_results.body.results;
-  for (let key in results) {
+  for (const key in results) {
     const result = results[key];
     const finding = {
       status: result.type,
@@ -35,6 +35,6 @@ export function loadFindings(proxyObject: object) {
     };
     findings.push(finding);
   }
-  console.log(findings)
+  console.log(findings);
   return findings;
 }

--- a/mlte/frontend/nuxt-app/layouts/base-layout.vue
+++ b/mlte/frontend/nuxt-app/layouts/base-layout.vue
@@ -114,7 +114,7 @@
         <slot name="default" />
         <footer>
           <p class="footer-text-left">
-            <b>MLTE - {{currentDate.getFullYear()}}</b>
+            <b>MLTE - {{ currentDate.getFullYear() }}</b>
           </p>
           <div class="footer-text-right">
             <a

--- a/mlte/frontend/nuxt-app/package-lock.json
+++ b/mlte/frontend/nuxt-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-app",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-app",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.22.9",

--- a/mlte/frontend/nuxt-app/pages/index.vue
+++ b/mlte/frontend/nuxt-app/pages/index.vue
@@ -208,8 +208,8 @@
       <UsaAccordionItem label="Test Suites">
         <div class="scrollable-table-div">
           <p>
-            A test suite defines the model requirements that must be
-            satisfied to ensure successful integration with the target system.
+            A test suite defines the model requirements that must be satisfied
+            to ensure successful integration with the target system.
           </p>
           <UsaTable
             :headers="testSuiteHeaders"
@@ -223,9 +223,9 @@
       <UsaAccordionItem label="Test Results">
         <div class="scrollable-table-div">
           <p>
-            Test Results are produced by combining a specification
-            with its corresponding results; this artifact communicates how well
-            a model performed against all of its requirements.
+            Test Results are produced by combining a specification with its
+            corresponding results; this artifact communicates how well a model
+            performed against all of its requirements.
           </p>
           <UsaTable
             :headers="testResultHeaders"
@@ -239,8 +239,8 @@
       <UsaAccordionItem label="Evidences">
         <div class="scrollable-table-div">
           <p>
-            Evidences are the atomic unit of model evaluation in MLTE. A value is
-            any artifact produced by a MLTE measurement for the purposes of
+            Evidences are the atomic unit of model evaluation in MLTE. A value
+            is any artifact produced by a MLTE measurement for the purposes of
             model evaluation.
           </p>
           <UsaTable

--- a/mlte/frontend/nuxt-app/pages/login.vue
+++ b/mlte/frontend/nuxt-app/pages/login.vue
@@ -119,11 +119,9 @@ async function submit() {
       },
       onResponse({ response }) {
         if (response.ok) {
-          const userRole = useCookie("userRole",
-            {
-              maxAge: expiresInTemp,
-            }
-          );
+          const userRole = useCookie("userRole", {
+            maxAge: expiresInTemp,
+          });
           userRole.value = response._data.role;
         }
       },
@@ -134,8 +132,8 @@ async function submit() {
 
     navigateTo("/");
   } catch (exception) {
-    console.log("Error in login: ")
-    console.log(exception)
+    console.log("Error in login: ");
+    console.log(exception);
   }
 }
 </script>

--- a/mlte/frontend/nuxt-app/pages/negotiation-card.vue
+++ b/mlte/frontend/nuxt-app/pages/negotiation-card.vue
@@ -254,9 +254,8 @@ if (useRoute().query.artifactId !== undefined) {
               ?.value !== undefined
           ) {
             form.value.nc_data.system.problem_type =
-              problemTypeOptions.value.find(
-                (x) => x.value === problemType,
-              )?.value;
+              problemTypeOptions.value.find((x) => x.value === problemType)
+                ?.value;
           }
 
           response._data.body.nc_data.data.forEach((item) => {

--- a/mlte/frontend/nuxt-app/pages/report-export.vue
+++ b/mlte/frontend/nuxt-app/pages/report-export.vue
@@ -59,7 +59,9 @@
       <thead>
         <tr>
           <th data-sortable scope="col" role="columnheader">Status</th>
-          <th data-sortable scope="col" role="columnheader">Quality Attribute Category</th>
+          <th data-sortable scope="col" role="columnheader">
+            Quality Attribute Category
+          </th>
           <th data-sortable scope="col" role="columnheader">Measurement</th>
           <th data-sortable scope="col" role="columnheader">Test Case ID</th>
           <th data-sortable scope="col" role="columnheader">Message</th>

--- a/mlte/frontend/nuxt-app/pages/report-form.vue
+++ b/mlte/frontend/nuxt-app/pages/report-form.vue
@@ -24,7 +24,9 @@
       <thead>
         <tr>
           <th data-sortable scope="col" role="columnheader">Status</th>
-          <th data-sortable scope="col" role="columnheader">Quality Attribute Category</th>
+          <th data-sortable scope="col" role="columnheader">
+            Quality Attribute Category
+          </th>
           <th data-sortable scope="col" role="columnheader">Measurement</th>
           <th data-sortable scope="col" role="columnheader">Test Case ID</th>
           <th data-sortable scope="col" role="columnheader">Message</th>
@@ -231,9 +233,8 @@ if (useRoute().query.artifactId !== undefined) {
                 ?.value !== undefined
             ) {
               form.value.nc_data.system.problem_type =
-                problemTypeOptions.value.find(
-                  (x) => x.value === problemType,
-                )?.value;
+                problemTypeOptions.value.find((x) => x.value === problemType)
+                  ?.value;
             }
 
             // Setting .value for each classification item to work in the select
@@ -251,8 +252,7 @@ if (useRoute().query.artifactId !== undefined) {
             });
 
             if (response._data.body.test_results_id) {
-              form.value.test_results_id =
-                response._data.body.test_results_id;
+              form.value.test_results_id = response._data.body.test_results_id;
               const testResults = await fetchArtifact(
                 token.value,
                 model,

--- a/mlte/store/custom_list/qa_categories/explainability.json
+++ b/mlte/store/custom_list/qa_categories/explainability.json
@@ -1,5 +1,0 @@
-{
-    "name": "Explainability",
-    "description": "Explainability",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/interoperability.json
+++ b/mlte/store/custom_list/qa_categories/interoperability.json
@@ -1,5 +1,0 @@
-{
-    "name": "Interoperability",
-    "description": "Interoperability",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/maintainability.json
+++ b/mlte/store/custom_list/qa_categories/maintainability.json
@@ -1,5 +1,0 @@
-{
-    "name": "Maintainability",
-    "description": "Maintainability",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/performance.json
+++ b/mlte/store/custom_list/qa_categories/performance.json
@@ -1,0 +1,5 @@
+{
+    "name": "Performance",
+    "description": "",
+    "parent": ""
+}

--- a/mlte/store/custom_list/qa_categories/privacy.json
+++ b/mlte/store/custom_list/qa_categories/privacy.json
@@ -1,5 +1,0 @@
-{
-    "name": "Privacy",
-    "description": "Privacy",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/resource-consumption.json
+++ b/mlte/store/custom_list/qa_categories/resource-consumption.json
@@ -1,5 +1,0 @@
-{
-    "name": "Resource Consumption",
-    "description": "Resource Consumption",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/safety.json
+++ b/mlte/store/custom_list/qa_categories/safety.json
@@ -1,5 +1,0 @@
-{
-    "name": "Safety",
-    "description": "Safety",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/scalability.json
+++ b/mlte/store/custom_list/qa_categories/scalability.json
@@ -1,5 +1,0 @@
-{
-    "name": "Scalability",
-    "description": "Scalability",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/security.json
+++ b/mlte/store/custom_list/qa_categories/security.json
@@ -1,5 +1,0 @@
-{
-    "name": "Security",
-    "description": "Security",
-    "parent": ""
-}

--- a/mlte/store/custom_list/qa_categories/testability.json
+++ b/mlte/store/custom_list/qa_categories/testability.json
@@ -1,5 +1,0 @@
-{
-    "name": "Testability",
-    "description": "Testability",
-    "parent": ""
-}

--- a/mlte/store/custom_list/quality_attributes/accuracy.json
+++ b/mlte/store/custom_list/quality_attributes/accuracy.json
@@ -1,0 +1,5 @@
+{
+    "name": "Accuracy",
+    "description": "",
+    "parent": "Functional Correctness"
+}

--- a/mlte/store/custom_list/quality_attributes/detect-out-of-dist.json
+++ b/mlte/store/custom_list/quality_attributes/detect-out-of-dist.json
@@ -1,0 +1,5 @@
+{
+    "name": "Detect Out-of-Distribution (OOD) Inputs",
+    "description": "",
+    "parent": "Monitorability"
+}

--- a/mlte/store/custom_list/quality_attributes/detect-shifts.json
+++ b/mlte/store/custom_list/quality_attributes/detect-shifts.json
@@ -1,0 +1,5 @@
+{
+    "name": "Detect Shifts in Output (Confidence) Distribution",
+    "description": "",
+    "parent": "Monitorability"
+}

--- a/mlte/store/custom_list/quality_attributes/inference-time.json
+++ b/mlte/store/custom_list/quality_attributes/inference-time.json
@@ -1,0 +1,5 @@
+{
+    "name": "Inference Time on Operational Platform",
+    "description": "",
+    "parent": "Performance"
+}

--- a/mlte/store/custom_list/quality_attributes/input-and-output-specification.json
+++ b/mlte/store/custom_list/quality_attributes/input-and-output-specification.json
@@ -1,0 +1,5 @@
+{
+    "name": "Input and Output Specification",
+    "description": "",
+    "parent": "Functional Correctness"
+}

--- a/mlte/store/custom_list/quality_attributes/input-validation.json
+++ b/mlte/store/custom_list/quality_attributes/input-validation.json
@@ -1,0 +1,5 @@
+{
+    "name": "Input Validation",
+    "description": "",
+    "parent": "Resilience"
+}

--- a/mlte/store/custom_list/quality_attributes/model-impartial-to-photo-location.json
+++ b/mlte/store/custom_list/quality_attributes/model-impartial-to-photo-location.json
@@ -1,0 +1,5 @@
+{
+    "name": "Model Impartial to Photo Location",
+    "description": "",
+    "parent": "Fairness"
+}

--- a/mlte/store/custom_list/quality_attributes/model-robust-to-noise-channel-loss.json
+++ b/mlte/store/custom_list/quality_attributes/model-robust-to-noise-channel-loss.json
@@ -1,0 +1,5 @@
+{
+    "name": "Model Robust to Noise (Channel Loss)",
+    "description": "",
+    "parent": "Robustness"
+}

--- a/mlte/store/custom_list/quality_attributes/model-robust-to-noise-image-blur.json
+++ b/mlte/store/custom_list/quality_attributes/model-robust-to-noise-image-blur.json
@@ -1,0 +1,5 @@
+{
+    "name": "Model Robust to Noise (Image Blur)",
+    "description": "",
+    "parent": "Robustness"
+}

--- a/mlte/store/custom_list/quality_attributes/resource-consumption.json
+++ b/mlte/store/custom_list/quality_attributes/resource-consumption.json
@@ -1,0 +1,5 @@
+{
+    "name": "Resource Consumption on Operational Platform",
+    "description": "",
+    "parent": "Performance"
+}

--- a/mlte/store/custom_list/quality_attributes/resource-usage.json
+++ b/mlte/store/custom_list/quality_attributes/resource-usage.json
@@ -1,0 +1,5 @@
+{
+    "name": "Resource Usage",
+    "description": "",
+    "parent": "Performance"
+}

--- a/mlte/store/custom_list/quality_attributes/understanding-model-results.json
+++ b/mlte/store/custom_list/quality_attributes/understanding-model-results.json
@@ -1,0 +1,5 @@
+{
+    "name": "Understanding Model Results",
+    "description": "",
+    "parent": "Interpretability"
+}


### PR DESCRIPTION
Addresses most of #517 and has a fair bit of random linting done by the linter that didn't get done before.

Does not address making sure that the demo negotiation card can be loaded as the QA in the example are not currently part of the sample catalog and so will not be populated in the drop downs. Would make the most sense to fix that once the rest of the team finishes their set of QAC/QA, so can make a separate issue for that, just can't forget to do it before the 2.0 release. 

Although, we did set the milestone for test catalog to be in August, well after the 2.0 release. So I suppose I could populate the default custom lists with the values needed for the example to work for now, and then update it later. What do you think makes the most sense?