### PR TITLE
Bugfix/sql alchemy crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ venv-clean:
 .PHONY: venv
 venv:
 	python -m venv .venv && \
+	poetry lock && \
 	poetry install --with dev,demo --all-extras
 
 .PHONY: venv-redo

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,6 @@ format:
 	poetry run black mlte/
 	poetry run black test/
 	poetry run black demo/
-	poetry run black demo/simple/*.ipynb
-	poetry run black demo/scenarios/*.ipynb
 	poetry run black tools/
 
 .PHONY: check-format 
@@ -71,8 +69,6 @@ check-format:
 	poetry run black --check mlte/
 	poetry run black --check test/
 	poetry run black --check demo/
-	poetry run black --check demo/simple/*.ipynb
-	poetry run black --check demo/scenarios/*.ipynb
 	poetry run black --check tools/
 
 # Lint all source code

--- a/demo/simple/3_evidence.ipynb
+++ b/demo/simple/3_evidence.ipynb
@@ -76,7 +76,6 @@
    "outputs": [],
    "source": [
     "from typing import Any\n",
-    "import typing\n",
     "\n",
     "from mlte.measurement.units import Units\n",
     "from mlte.tests.test_suite import TestSuite\n",
@@ -92,7 +91,7 @@
     "}\n",
     "\n",
     "# Load the TestSuite, and run measurements on all cases with the given inputs.\n",
-    "test_suite = typing.cast(TestSuite, TestSuite.load())\n",
+    "test_suite = TestSuite.load()\n",
     "evidences = test_suite.run_measurements(test_inputs)\n",
     "\n",
     "# Save all evidence to the store.\n",

--- a/mlte/store/artifact/factory.py
+++ b/mlte/store/artifact/factory.py
@@ -8,7 +8,6 @@ from mlte.store.artifact.store import ArtifactStore
 from mlte.store.artifact.underlying.fs import LocalFileSystemStore
 from mlte.store.artifact.underlying.http import HttpArtifactStore
 from mlte.store.artifact.underlying.memory import InMemoryStore
-from mlte.store.artifact.underlying.rdbs.store import RelationalDBArtifactStore
 from mlte.store.base import StoreType, StoreURI
 
 
@@ -26,6 +25,11 @@ def create_artifact_store(uri: str) -> ArtifactStore:
     if parsed_uri.type == StoreType.REMOTE_HTTP:
         return HttpArtifactStore(uri=parsed_uri)
     if parsed_uri.type == StoreType.RELATIONAL_DB:
+        # Import is here to avoid importing SQL libraries if they have not been installed.
+        from mlte.store.artifact.underlying.rdbs.store import (
+            RelationalDBArtifactStore,
+        )
+
         return RelationalDBArtifactStore(parsed_uri)
     else:
         raise Exception(

--- a/mlte/store/catalog/factory.py
+++ b/mlte/store/catalog/factory.py
@@ -11,7 +11,6 @@ from mlte.store.catalog.store import CatalogStore
 from mlte.store.catalog.underlying.fs import FileSystemCatalogStore
 from mlte.store.catalog.underlying.http import HttpCatalogGroupStore
 from mlte.store.catalog.underlying.memory import InMemoryCatalogStore
-from mlte.store.catalog.underlying.rdbs.store import RelationalDBCatalogStore
 
 
 def create_catalog_store(
@@ -29,6 +28,11 @@ def create_catalog_store(
     if parsed_uri.type == StoreType.LOCAL_FILESYSTEM:
         return FileSystemCatalogStore(uri=parsed_uri, catalog_folder=catalog_id)
     if parsed_uri.type == StoreType.RELATIONAL_DB:
+        # Import is here to avoid importing SQL libraries if they have not been installed.
+        from mlte.store.catalog.underlying.rdbs.store import (
+            RelationalDBCatalogStore,
+        )
+
         return RelationalDBCatalogStore(uri=parsed_uri)
     if parsed_uri.type == StoreType.REMOTE_HTTP:
         return HttpCatalogGroupStore(uri=parsed_uri)

--- a/mlte/store/custom_list/factory.py
+++ b/mlte/store/custom_list/factory.py
@@ -5,7 +5,6 @@ from mlte.store.custom_list.store import CustomListStore
 from mlte.store.custom_list.underlying.fs import FileSystemCustomListStore
 from mlte.store.custom_list.underlying.memory import InMemoryCustomListStore
 
-# from mlte.store.custom_list.underlying.rdbs.store import RelationalDBCustomListStore
 # from mlte.store.custom_list.underlying.rdbs.store import HttpCustomListStore
 
 
@@ -20,7 +19,9 @@ def create_custom_list_store(uri: str) -> CustomListStore:
     if parsed_uri.type == StoreType.LOCAL_MEMORY:
         return InMemoryCustomListStore(parsed_uri)
     #   elif parsed_uri.type == StoreType.RELATIONAL_DB:
-    # return RelationalDBCustomListStore(parsed_uri)
+    #       Import is here to avoid importing SQL libraries if they have not been installed.
+    #       from mlte.store.custom_list.underlying.rdbs.store import RelationalDBCustomListStore
+    #       return RelationalDBCustomListStore(parsed_uri)
     elif parsed_uri.type == StoreType.LOCAL_FILESYSTEM:
         return FileSystemCustomListStore(parsed_uri)
     #   elif parsed_uri.type == StoreType.REMOTE_HTTP:

--- a/mlte/store/user/factory.py
+++ b/mlte/store/user/factory.py
@@ -8,7 +8,6 @@ from mlte.store.base import StoreType, StoreURI
 from mlte.store.user.store import UserStore
 from mlte.store.user.underlying.fs import FileSystemUserStore
 from mlte.store.user.underlying.memory import InMemoryUserStore
-from mlte.store.user.underlying.rdbs.store import RelationalDBUserStore
 
 
 def create_user_store(uri: str) -> UserStore:
@@ -21,6 +20,9 @@ def create_user_store(uri: str) -> UserStore:
     if parsed_uri.type == StoreType.LOCAL_MEMORY:
         return InMemoryUserStore(parsed_uri)
     if parsed_uri.type == StoreType.RELATIONAL_DB:
+        # Import is here to avoid importing SQL libraries if they have not been installed.
+        from mlte.store.user.underlying.rdbs.store import RelationalDBUserStore
+
         return RelationalDBUserStore(parsed_uri)
     if parsed_uri.type == StoreType.LOCAL_FILESYSTEM:
         return FileSystemUserStore(parsed_uri)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ known_first_party=["mlte", "test"]
 [tool.black]
 line-length = 80
 target-version = ['py38']
+include = '\.pyi?$|\.ipynb$'
 
 [tool.mypy]
 mypy_path = "src"


### PR DESCRIPTION
Addresses #674 by moving imports to the corresponding RDBS implementations for the different stores, to the case in each factory where the RDBS is instanced, to avoid trying to load SQL-related libraries when they have not been installed, since they are now optional and not installed by default. 

High priority fix, since currently released 2.0.0 version will crash every time if SQL libraries are not installed.

Other minor fixes:
 - Simplified makefile command for black formatter adding Jupyter files to its configuration
 - Added poetry lock (without updates) to venv command to always ensure it is up to date before installing
 - Minor removal of (now) unneeded cast in simple demo.