### PR TITLE
Feature/catalog uri

### DIFF
--- a/mlte/artifact/artifact.py
+++ b/mlte/artifact/artifact.py
@@ -101,7 +101,7 @@ class Artifact(Serializable):
         """
         return self.save_with(
             session().context,
-            session().artifact_store,
+            session().stores.artifact_store,
             force=force,
             parents=parents,
             user=user,
@@ -161,7 +161,7 @@ class Artifact(Serializable):
         return cls.load_with(
             identifier,
             context=session().context,
-            store=session().artifact_store,
+            store=session().stores.artifact_store,
         )
 
     @classmethod
@@ -205,7 +205,7 @@ class Artifact(Serializable):
         return Artifact.load_models(
             artifact_type,
             context=session().context,
-            store=session().artifact_store,
+            store=session().stores.artifact_store,
         )
 
     @staticmethod

--- a/mlte/backend/api/endpoints/artifact.py
+++ b/mlte/backend/api/endpoints/artifact.py
@@ -45,7 +45,7 @@ def write_artifact(
         artifact = ArtifactFactory.from_model(request.artifact)
         model = artifact.save_with(
             Context(model_id, version_id),
-            state.artifact_store,
+            state.stores.artifact_store,
             force=request.force,
             parents=request.parents,
             user=current_user.username,

--- a/mlte/backend/core/config.py
+++ b/mlte/backend/core/config.py
@@ -54,9 +54,7 @@ class Settings(BaseSettings):
     STORE_URI: str = StoreURI.create_uri_string(StoreType.LOCAL_MEMORY)
     """The store URI string; defaults to in-memory store."""
 
-    CATALOG_URIS: Dict[str, str] = {
-        "local": StoreURI.create_uri_string(StoreType.LOCAL_MEMORY)
-    }
+    CATALOG_URIS: Dict[str, str] = {}
     """The dict of catalog URI strings; defaults to one in-memory store."""
 
     LOG_LEVEL: str = "ERROR"

--- a/mlte/backend/core/state.py
+++ b/mlte/backend/core/state.py
@@ -1,18 +1,8 @@
-"""
-mlte/backend/core/state.py
-
-Globally-accessible application state.
-"""
+"""Globally-accessible application state."""
 
 from __future__ import annotations
 
-from typing import Optional
-
-from mlte.store.artifact.store import ArtifactStore
-from mlte.store.catalog.catalog_group import CatalogStoreGroup
-from mlte.store.catalog.store import CatalogStore
-from mlte.store.custom_list.store import CustomListStore
-from mlte.store.user.store import UserStore
+from mlte.session.session_stores import SessionStores
 
 
 class State:
@@ -23,67 +13,16 @@ class State:
 
     def reset(self):
         """Resets all internal state to defaults."""
-        self._artifact_store: Optional[ArtifactStore] = None
-        """The artifact store instance maintained by the state object."""
 
-        self._user_store: Optional[UserStore] = None
-        """The user store instance maintained by the state object."""
-
-        self._catalog_stores: CatalogStoreGroup = CatalogStoreGroup()
-        """The list of catalog store instances maintained by the state object."""
-
-        self._custom_list_store: Optional[CustomListStore] = None
-        """The custom list store instance maintained by the state object."""
+        self.stores = SessionStores()
+        """All stores in this session."""
 
         self._jwt_secret_key: str = ""
         """Secret key used to sign authentication tokens."""
 
-    def set_artifact_store(self, store: ArtifactStore):
-        """Set the globally-configured backend artifact store."""
-        self._artifact_store = store
-
-    def set_user_store(self, store: UserStore):
-        """Set the globally-configured backend user store."""
-        self._user_store = store
-
-    def add_catalog_store(
-        self, store: CatalogStore, id: str, overwite: bool = False
-    ):
-        """Adds to the the globally-configured backend list of catalog stores."""
-        self._catalog_stores.add_catalog(id, store, overwite)
-
-    def add_catalog_store_from_uri(
-        self, store_uri: str, id: str, overwite: bool = False
-    ):
-        """Adds to the the globally-configured backend list of catalog stores."""
-        self._catalog_stores.add_catalog_from_uri(id, store_uri, overwite)
-
-    def set_custom_list_store(self, store: CustomListStore):
-        """Set the globally-configured backend custom list store."""
-        self._custom_list_store = store
-
     def set_token_key(self, token_key: str):
         """Sets the globally used token secret key."""
         self._jwt_secret_key = token_key
-
-    @property
-    def artifact_store(self) -> ArtifactStore:
-        """Get the globally-configured backend artifact store."""
-        if self._artifact_store is None:
-            raise RuntimeError("Artifact store is not configured.")
-        return self._artifact_store
-
-    @property
-    def user_store(self) -> UserStore:
-        """Get the globally-configured backend user store."""
-        if self._user_store is None:
-            raise RuntimeError("User store is not configured.")
-        return self._user_store
-
-    @property
-    def catalog_stores(self) -> CatalogStoreGroup:
-        """Get the globally-configured backend catalog store group."""
-        return self._catalog_stores
 
     @property
     def token_key(self) -> str:
@@ -91,13 +30,6 @@ class State:
         if self._jwt_secret_key == "":
             raise RuntimeError("Token key has not been configured.")
         return self._jwt_secret_key
-
-    @property
-    def custom_list_store(self) -> CustomListStore:
-        """Get the globablly-configured backend custom list store."""
-        if self._custom_list_store is None:
-            raise RuntimeError("Custom list store is not configured.")
-        return self._custom_list_store
 
 
 # Globally-accessible application state

--- a/mlte/backend/core/state_stores.py
+++ b/mlte/backend/core/state_stores.py
@@ -20,7 +20,7 @@ def artifact_store_session() -> Generator[ArtifactStoreSession, None, None]:
     Get a handle to underlying store session.
     :return: The session handle
     """
-    session: ArtifactStoreSession = state.artifact_store.session()
+    session: ArtifactStoreSession = state.stores.artifact_store.session()
     try:
         yield session
     finally:
@@ -33,7 +33,7 @@ def user_store_session() -> Generator[UserStoreSession, None, None]:
     Get a handle to underlying store session.
     :return: The session handle
     """
-    session: UserStoreSession = state.user_store.session()
+    session: UserStoreSession = state.stores.user_store.session()
     try:
         yield session
     finally:
@@ -46,7 +46,7 @@ def catalog_stores_session() -> Generator[CatalogStoreGroupSession, None, None]:
     Get a handle to underlying store session.
     :return: The session handle
     """
-    session: CatalogStoreGroupSession = state.catalog_stores.session()
+    session: CatalogStoreGroupSession = state.stores.catalog_stores.session()
     try:
         yield session
     finally:
@@ -61,7 +61,7 @@ def custom_list_stores_session() -> (
     Get a handle to underlying store session.
     :return: The session handle
     """
-    session: CustomListStoreSession = state.custom_list_store.session()
+    session: CustomListStoreSession = state.stores.custom_list_store.session()
     try:
         yield session
     finally:

--- a/mlte/backend/main.py
+++ b/mlte/backend/main.py
@@ -93,21 +93,21 @@ def _setup_stores(stores_uri: str, catalog_uris: dict[str, str]):
     artifact_store = artifact_store_factory.create_artifact_store(stores_uri)
     if artifact_store.uri.type == StoreType.REMOTE_HTTP:
         raise RuntimeError("Cannot run backend with HTTP artifact store.")
-    state.set_artifact_store(artifact_store)
+    state.stores.set_artifact_store(artifact_store)
 
     # Initialize the backing user store instance. Assume same store as artifact one for now.
     # TODO: allow for separate config of uri here?
     user_store = user_store_factory.create_user_store(stores_uri)
-    state.set_user_store(user_store)
+    state.stores.set_user_store(user_store)
 
     # Initialize the backing custom list store instance. Assume same store as artifact one for now.
     # TODO: allow for separate config of uri here?
     custom_list_store = InitialCustomLists.setup_custom_list_store(stores_uri)
-    state.set_custom_list_store(custom_list_store)
+    state.stores.set_custom_list_store(custom_list_store)
 
     # Catalogs: first add the sample catalog store.
     sample_catalog = SampleCatalog.setup_sample_catalog(stores_uri)
-    state.add_catalog_store(
+    state.stores.add_catalog_store(
         store=sample_catalog, id=SampleCatalog.SAMPLE_CATALOG_ID
     )
 
@@ -116,7 +116,7 @@ def _setup_stores(stores_uri: str, catalog_uris: dict[str, str]):
         logging.info(
             f"Adding catalog with id '{id}' and URI of type: {StoreURI.from_string(uri).type}"
         )
-        state.add_catalog_store_from_uri(uri, id)
+        state.stores.add_catalog_store_from_uri(uri, id)
 
 
 def main() -> int:

--- a/mlte/session/session.py
+++ b/mlte/session/session.py
@@ -1,21 +1,16 @@
-"""
-mlte/session/session.py
+"""Manages session info: context (model and version) and stores."""
 
-Session state management for the MLTE library.
-"""
+from __future__ import annotations
 
 import os
-import typing
 from typing import Optional
 
 import mlte.store.artifact.util as storeutil
 from mlte.context.context import Context
 from mlte.custom_list.custom_list_names import CustomListName
+from mlte.session.session_stores import SessionStores
 from mlte.store.artifact.factory import create_artifact_store
-from mlte.store.artifact.store import ArtifactStore
-from mlte.store.catalog.catalog_group import CatalogStoreGroup
 from mlte.store.custom_list.initial_custom_lists import InitialCustomLists
-from mlte.store.custom_list.store import CustomListStore
 
 
 class Session:
@@ -30,31 +25,31 @@ class Session:
     MLTE_CONTEXT_VERSION_VAR = "MLTE_CONTEXT_VERSION"
     """Environment variables to get model and version from, if needed."""
 
-    MLTE_ARTIFACT_STORE_URI_VAR = "MLTE_ARTIFACT_STORE_URI"
-    """Environment variable to get the artifact store URI from, if needed."""
-
-    MLTE_CUSTOM_LIST_STORE_URI_VAR = "MLTE_CUSTOM_LIST_STORE_URI"
-    """Environment variable to get the custom list store URI from, if needed."""
-
-    _instance = None
+    _instance: Optional[Session] = None
+    """Singleton instance."""
 
     def __new__(self):
+        """Overload to ensure it is a singleton."""
         if self._instance is None:
             self._instance = super(Session, self).__new__(self)
         return self._instance
 
     def __init__(self):
+        """Constructors, just resets all vars."""
+        self.reset()
+
+    def reset(self):
+        """Resets all internal state to defaults."""
         self._context: Optional[Context] = None
         """The MLTE context for the session."""
 
-        self._artifact_store: Optional[ArtifactStore] = None
-        """The MLTE artifct store instance for the session."""
+        self.stores = SessionStores()
+        """All stores in this session."""
 
-        self._custom_list_store: Optional[CustomListStore] = None
-        """The MLTE custom list store instance for the session."""
-
-        self._catalog_stores: CatalogStoreGroup = CatalogStoreGroup()
-        """The list of catalog store instances maintained by the session object."""
+    @staticmethod
+    def get_session() -> Session:
+        """Obtains the singleton instance."""
+        return Session()
 
     @property
     def context(self) -> Context:
@@ -73,86 +68,31 @@ class Session:
 
         return self._context
 
-    @property
-    def artifact_store(self) -> ArtifactStore:
-        if self._artifact_store is None:
-            # If the artifact store URI has not been manually set, get it from environment.
-            store_uri = self._get_env_var(self.MLTE_ARTIFACT_STORE_URI_VAR)
-            if store_uri:
-                self._artifact_store = create_artifact_store(store_uri)
-            else:
-                raise RuntimeError(
-                    "Must initialize MLTE artifact store for session, either manually or through environment variables."
-                )
-        return self._artifact_store
-
-    @property
-    def custom_list_store(self) -> CustomListStore:
-        if self._custom_list_store is None:
-            # If the custom list store URI has not been manually set, get it from environment.
-            store_uri = self._get_env_var(self.MLTE_CUSTOM_LIST_STORE_URI_VAR)
-            if store_uri:
-                self._custom_list_store = (
-                    InitialCustomLists.setup_custom_list_store(store_uri)
-                )
-            else:
-                raise RuntimeError(
-                    "Must initialize MLTE custom list store for session, either manually or through environment variables."
-                )
-
-        return self._custom_list_store
-
-    @property
-    def catalog_stores(self) -> CatalogStoreGroup:
-        return self._catalog_stores
-
     def _set_context(self, context: Context) -> None:
         """Set the session context."""
         self._context = context
 
     def _get_env_var(self, env_var: str) -> Optional[str]:
         """Get env var or return none if does not exist."""
-        if env_var in os.environ:
-            return typing.cast(str, os.getenv(env_var))
-        else:
-            return None
-
-    def _set_artifact_store(self, artifact_store: ArtifactStore) -> None:
-        """Set the session artifact store."""
-        self._artifact_store = artifact_store
-
-    def _set_custom_list_store(
-        self, custom_list_store: CustomListStore
-    ) -> None:
-        """Set the session custom list store."""
-        self._custom_list_store = custom_list_store
-
-    def _add_catalog_store(self, store_uri: str, id: str):
-        """Adds a catalog store."""
-        self._catalog_stores.add_catalog_from_uri(id, store_uri)
+        return os.environ.get(env_var, None)
 
     def create_context(self):
         """Creates the currently configured context in the currently configured session. Fails if either is not set. Does nothing if already created."""
-        artifact_store = self.artifact_store
+        artifact_store = self.stores.artifact_store
         context = self.context
         storeutil.create_parents(
             artifact_store.session(), context.model, context.version
         )
 
 
-# Singleton session.
-g_session = Session()
-
-
 def reset_session() -> None:
     """Used to reset session if needed."""
-    global g_session
-    g_session = Session()
+    Session.get_session().reset()
 
 
 def session() -> Session:
     """Return the package global session."""
-    return g_session
+    return Session.get_session()
 
 
 def set_context(model_id: str, version_id: str, lazy: bool = True):
@@ -162,10 +102,10 @@ def set_context(model_id: str, version_id: str, lazy: bool = True):
     :param version_id: The version identifier
     :param lazy: Whether to wait to create the context until an artifact is written (True), or to eagerly create it immediately (False).
     """
-    global g_session
-    g_session._set_context(Context(model_id, version_id))
+    session = Session.get_session()
+    session._set_context(Context(model_id, version_id))
     if not lazy:
-        g_session.create_context()
+        session.create_context()
 
 
 def set_store(store_uri: str):
@@ -173,9 +113,9 @@ def set_store(store_uri: str):
     Set the global MLTE context store URI.
     :param store_uri: The store URI string
     """
-    global g_session
-    g_session._set_artifact_store(create_artifact_store(store_uri))
-    g_session._set_custom_list_store(
+    session = Session.get_session()
+    session.stores.set_artifact_store(create_artifact_store(store_uri))
+    session.stores.set_custom_list_store(
         InitialCustomLists.setup_custom_list_store(store_uri)
     )
 
@@ -185,14 +125,14 @@ def add_catalog_store(catalog_store_uri: str, id: str):
     Adds a global MLTE catalog store URI.
     :param catalog_store_uri: The catalog store URI string
     """
-    global g_session
-    g_session._add_catalog_store(catalog_store_uri, id)
+    session = Session.get_session()
+    session.stores.add_catalog_store_from_uri(catalog_store_uri, id)
 
 
 def print_custom_list_entries(list_name: CustomListName) -> None:
     """Prints custom list entries in a user-friendly way."""
-    global g_session
-    entry_list = g_session.custom_list_store.session().custom_list_entry_mapper.list_details(
+    session = Session.get_session()
+    entry_list = session.stores.custom_list_store.session().custom_list_entry_mapper.list_details(
         list_name
     )
     for entry in entry_list:

--- a/mlte/session/session.py
+++ b/mlte/session/session.py
@@ -8,9 +8,7 @@ from typing import Optional
 import mlte.store.artifact.util as storeutil
 from mlte.context.context import Context
 from mlte.custom_list.custom_list_names import CustomListName
-from mlte.session.session_stores import SessionStores
-from mlte.store.artifact.factory import create_artifact_store
-from mlte.store.custom_list.initial_custom_lists import InitialCustomLists
+from mlte.session.session_stores import SessionStores, setup_stores
 
 
 class Session:
@@ -114,10 +112,7 @@ def set_store(store_uri: str):
     :param store_uri: The store URI string
     """
     session = Session.get_session()
-    session.stores.set_artifact_store(create_artifact_store(store_uri))
-    session.stores.set_custom_list_store(
-        InitialCustomLists.setup_custom_list_store(store_uri)
-    )
+    session.stores = setup_stores(store_uri)
 
 
 def add_catalog_store(catalog_store_uri: str, id: str):

--- a/mlte/session/session_stores.py
+++ b/mlte/session/session_stores.py
@@ -145,13 +145,11 @@ def setup_stores(
     stores.set_artifact_store(artifact_store)
 
     # Initialize the backing user store instance. Assume same store as artifact one for now.
-    # TODO: allow for separate config of uri here?
     if set_user_store:
         user_store = user_store_factory.create_user_store(stores_uri)
         stores.set_user_store(user_store)
 
     # Initialize the backing custom list store instance. Assume same store as artifact one for now.
-    # TODO: allow for separate config of uri here?
     custom_list_store = InitialCustomLists.setup_custom_list_store(stores_uri)
     stores.set_custom_list_store(custom_list_store)
 

--- a/mlte/session/session_stores.py
+++ b/mlte/session/session_stores.py
@@ -1,0 +1,120 @@
+"""Manages current session info about stores."""
+
+import os
+from typing import Optional
+
+from mlte.store.artifact.factory import create_artifact_store
+from mlte.store.artifact.store import ArtifactStore
+from mlte.store.catalog.catalog_group import CatalogStoreGroup
+from mlte.store.catalog.store import CatalogStore
+from mlte.store.custom_list.initial_custom_lists import InitialCustomLists
+from mlte.store.custom_list.store import CustomListStore
+from mlte.store.user.factory import create_user_store
+from mlte.store.user.store import UserStore
+
+
+class SessionStores:
+    """
+    Contains the store sessions currently being used.
+    """
+
+    ENV_ARTIFACT_STORE_URI_VAR = "MLTE_ARTIFACT_STORE_URI"
+    """Environment variable to get the artifact store URI from, if needed."""
+
+    ENV_CUSTOM_LIST_STORE_URI_VAR = "MLTE_CUSTOM_LIST_STORE_URI"
+    """Environment variable to get the custom list store URI from, if needed."""
+
+    ENV_USER_STORE_URI_VAR = "MLTE_CUSTOM_LIST_STORE_URI"
+    """Environment variable to get the custom list store URI from, if needed."""
+
+    def __init__(self):
+        """Defines the existing stores, none loaded yet."""
+
+        self._artifact_store: Optional[ArtifactStore] = None
+        """The MLTE artifact store instance for the session."""
+
+        self._custom_list_store: Optional[CustomListStore] = None
+        """The MLTE custom list store instance for the session."""
+
+        self._user_store: Optional[UserStore] = None
+        """The user store instance for the session."""
+
+        self._catalog_stores: CatalogStoreGroup = CatalogStoreGroup()
+        """The list of catalog store instances maintained by the session object."""
+
+    def set_artifact_store(self, store: ArtifactStore) -> None:
+        """Set the globally-configured backend artifact store."""
+        self._artifact_store = store
+
+    def set_custom_list_store(self, store: CustomListStore) -> None:
+        """Set the globally-configured backend custom list store."""
+        self._custom_list_store = store
+
+    def set_user_store(self, store: UserStore) -> None:
+        """Set the globally-configured backend user store."""
+        self._user_store = store
+
+    def add_catalog_store(
+        self, store: CatalogStore, id: str, overwite: bool = False
+    ) -> None:
+        """Adds to the the globally-configured backend list of catalog stores."""
+        self._catalog_stores.add_catalog(id, store, overwite)
+
+    def add_catalog_store_from_uri(
+        self, store_uri: str, id: str, overwite: bool = False
+    ) -> None:
+        """Adds to the the globally-configured backend list of catalog stores."""
+        self._catalog_stores.add_catalog_from_uri(id, store_uri, overwite)
+
+    @property
+    def artifact_store(self) -> ArtifactStore:
+        """Get the session artifact store."""
+        if self._artifact_store is None:
+            # If the URI has not been manually set, get it from environment.
+            store_uri = self._get_env_var(self.ENV_ARTIFACT_STORE_URI_VAR)
+            if store_uri:
+                self._artifact_store = create_artifact_store(store_uri)
+            else:
+                raise RuntimeError(
+                    "Must initialize artifact store, either manually or through environment variables."
+                )
+        return self._artifact_store
+
+    @property
+    def custom_list_store(self) -> CustomListStore:
+        """Get the session custom list store."""
+        if self._custom_list_store is None:
+            # If the store URI has not been manually set, get it from environment.
+            store_uri = self._get_env_var(self.ENV_CUSTOM_LIST_STORE_URI_VAR)
+            if store_uri:
+                self._custom_list_store = (
+                    InitialCustomLists.setup_custom_list_store(store_uri)
+                )
+            else:
+                raise RuntimeError(
+                    "Must initialize custom list store, either manually or through environment variables."
+                )
+        return self._custom_list_store
+
+    @property
+    def user_store(self) -> UserStore:
+        """Get session user store."""
+        if self._user_store is None:
+            # If the store URI has not been manually set, get it from environment.
+            store_uri = self._get_env_var(self.ENV_USER_STORE_URI_VAR)
+            if store_uri:
+                self._user_store = create_user_store(store_uri)
+            else:
+                raise RuntimeError(
+                    "Must initialize user store, either manually or through environment variables."
+                )
+        return self._user_store
+
+    @property
+    def catalog_stores(self) -> CatalogStoreGroup:
+        """Get all catalog stores."""
+        return self._catalog_stores
+
+    def _get_env_var(self, env_var: str) -> Optional[str]:
+        """Get env var or return none if does not exist."""
+        return os.environ.get(env_var, None)

--- a/test/backend/api/auth/test_authentication.py
+++ b/test/backend/api/auth/test_authentication.py
@@ -29,13 +29,12 @@ def set_user_store_in_state(
 ):
     """Sets an provided fixture user store in the backend state."""
     user_store: UserStore = request.getfixturevalue(store_fixture_name)
-    state.set_user_store(user_store)
+    state.stores.set_user_store(user_store)
 
 
 def clear_state():
     """Clears the the backend state."""
-    state._artifact_store = None
-    state._user_store = None
+    state.reset()
 
 
 def set_test_user(

--- a/test/backend/api/endpoints/artifact/test_model.py
+++ b/test/backend/api/endpoints/artifact/test_model.py
@@ -75,7 +75,7 @@ def test_create(test_api_fixture, api_user: UserWithPassword) -> None:
     _ = Model(**res.json())
 
     # Also test that permissions and groups were created.
-    with ManagedUserSession(state.user_store.session()) as user_store:
+    with ManagedUserSession(state.stores.user_store.session()) as user_store:
         assert Policy(ResourceType.MODEL, model.identifier).is_stored(
             user_store
         )
@@ -193,7 +193,7 @@ def test_delete(test_api_fixture, api_user: UserWithPassword) -> None:
     assert res.status_code == codes.NOT_FOUND
 
     # Also test that permissions and groups were deleted
-    with ManagedUserSession(state.user_store.session()) as user_store:
+    with ManagedUserSession(state.stores.user_store.session()) as user_store:
         assert not Policy(ResourceType.MODEL, model.identifier).is_stored(
             user_store
         )

--- a/test/backend/api/endpoints/test_group.py
+++ b/test/backend/api/endpoints/test_group.py
@@ -64,7 +64,7 @@ def get_test_group() -> Group:
 def create_group_using_admin(api: TestAPI):
     """Create test group."""
     group = get_test_group()
-    with ManagedUserSession(state.user_store.session()) as user_store:
+    with ManagedUserSession(state.stores.user_store.session()) as user_store:
         setup_group_permisisons(group, user_store)
 
     api.admin_create_entity(get_test_group(), GROUP_URI)
@@ -127,7 +127,7 @@ def test_edit(test_api_fixture, api_user: UserWithPassword) -> None:  # noqa
         resource_id="mod1",
         method=MethodType.DELETE,
     )
-    with ManagedUserSession(state.user_store.session()) as user_store:
+    with ManagedUserSession(state.stores.user_store.session()) as user_store:
         user_store.permission_mapper.create(p3)
 
     # Create test group.
@@ -159,7 +159,7 @@ def test_edit_no_permission(
         resource_id="mod1",
         method=MethodType.DELETE,
     )
-    with ManagedUserSession(state.user_store.session()) as user_store:
+    with ManagedUserSession(state.stores.user_store.session()) as user_store:
         user_store.permission_mapper.create(p3)
 
     # Create test group.

--- a/test/backend/api/endpoints/test_user.py
+++ b/test/backend/api/endpoints/test_user.py
@@ -305,7 +305,7 @@ def test_delete(test_api_fixture, api_user: UserWithPassword) -> None:
     assert res.status_code == codes.NOT_FOUND
 
     assert not Policy(ResourceType.USER, user.username).is_stored(
-        state.user_store.session()
+        state.stores.user_store.session()
     )
 
 
@@ -350,7 +350,7 @@ def test_list_user_groups(test_api_fixture, api_user: UserWithPassword) -> None:
     # Give user permissions to some models.
     user.groups.extend(Policy(ResourceType.MODEL, resource_id=m1_id).groups)
     user.groups.extend(Policy(ResourceType.MODEL, resource_id=m2_id).groups)
-    user_store = state.user_store.session()
+    user_store = state.stores.user_store.session()
     user_store.user_mapper.edit(user)
 
     res = test_client.get(f"{USER_URI}/{user.username}/models")
@@ -384,7 +384,7 @@ def test_list_user_groups_me(
     # Give user permissions to some models.
     api_user.groups.extend(Policy(ResourceType.MODEL, resource_id=m1_id).groups)
     api_user.groups.extend(Policy(ResourceType.MODEL, resource_id=m2_id).groups)
-    user_store = state.user_store.session()
+    user_store = state.stores.user_store.session()
     user_store.user_mapper.edit(BasicUser(**api_user.to_json()))
 
     res = test_client.get(f"{USER_URI}/me/models")

--- a/test/backend/fixture/test_api.py
+++ b/test/backend/fixture/test_api.py
@@ -93,13 +93,15 @@ class TestAPI:
 
         # Set up API global state.
         state.reset()
-        state.set_user_store(user_store_fixture.create_memory_store())
-        state.set_artifact_store(artifact_store_creators.create_memory_store())
+        state.stores.set_user_store(user_store_fixture.create_memory_store())
+        state.stores.set_artifact_store(
+            artifact_store_creators.create_memory_store()
+        )
         if default_catalog_id:
-            state.add_catalog_store(
+            state.stores.add_catalog_store(
                 catalog_store_creators.create_memory_store(), default_catalog_id
             )
-        state.set_custom_list_store(
+        state.stores.set_custom_list_store(
             custom_list_store_creators.create_memory_store()
         )
         state.set_token_key(TEST_JWT_TOKEN_SECRET)
@@ -110,14 +112,14 @@ class TestAPI:
 
     def set_user(self, user: Optional[UserWithPassword]):
         """Set up default user to use API."""
-        user_store = typing.cast(InMemoryUserStore, state.user_store)
+        user_store = typing.cast(InMemoryUserStore, state.stores.user_store)
         self.user = user
         if user is not None:
             self._set_user_in_mem_store(user, user_store)
 
     def set_admin_user(self):
         """Sets an admin user."""
-        user_store = typing.cast(InMemoryUserStore, state.user_store)
+        user_store = typing.cast(InMemoryUserStore, state.stores.user_store)
         self._set_user_in_mem_store(
             user_generator.build_admin_user(), user_store
         )

--- a/test/session/test_session.py
+++ b/test/session/test_session.py
@@ -10,6 +10,7 @@ import pytest
 
 from mlte.session import session, set_context, set_store
 from mlte.session.session import Session, add_catalog_store, reset_session
+from mlte.session.session_stores import SessionStores
 from mlte.store.artifact.store import ArtifactStore
 from mlte.store.base import StoreType, StoreURI
 
@@ -44,9 +45,9 @@ def test_session() -> None:
 
     assert s.context.model == model
     assert s.context.version == version
-    assert s.artifact_store.uri.uri == store_uri
-    assert s.custom_list_store.uri.uri == store_uri
-    assert s.catalog_stores.catalogs[cat_id].uri.uri == catalog_store_uri
+    assert s.stores.artifact_store.uri.uri == store_uri
+    assert s.stores.custom_list_store.uri.uri == store_uri
+    assert s.stores.catalog_stores.catalogs[cat_id].uri.uri == catalog_store_uri
 
 
 @pytest.mark.parametrize("store_fixture_name", artifact_stores())
@@ -67,9 +68,13 @@ def test_eager_context_creation(
 
     s = session()
 
-    assert s.artifact_store.session().read_model(model).identifier == model
     assert (
-        s.artifact_store.session().read_version(model, version).identifier
+        s.stores.artifact_store.session().read_model(model).identifier == model
+    )
+    assert (
+        s.stores.artifact_store.session()
+        .read_version(model, version)
+        .identifier
         == version
     )
 
@@ -82,20 +87,22 @@ def test_environment_vars():
 
     os.environ[Session.MLTE_CONTEXT_MODEL_VAR] = model
     os.environ[Session.MLTE_CONTEXT_VERSION_VAR] = version
-    os.environ[Session.MLTE_ARTIFACT_STORE_URI_VAR] = artifact_store_uri
-    os.environ[Session.MLTE_CUSTOM_LIST_STORE_URI_VAR] = custom_list_store_uri
+    os.environ[SessionStores.ENV_ARTIFACT_STORE_URI_VAR] = artifact_store_uri
+    os.environ[SessionStores.ENV_CUSTOM_LIST_STORE_URI_VAR] = (
+        custom_list_store_uri
+    )
 
     s = session()
 
     assert s.context.model == model
     assert s.context.version == version
-    assert s.artifact_store.uri.uri == artifact_store_uri
-    assert s.custom_list_store.uri.uri == custom_list_store_uri
+    assert s.stores.artifact_store.uri.uri == artifact_store_uri
+    assert s.stores.custom_list_store.uri.uri == custom_list_store_uri
 
     del os.environ[Session.MLTE_CONTEXT_MODEL_VAR]
     del os.environ[Session.MLTE_CONTEXT_VERSION_VAR]
-    del os.environ[Session.MLTE_ARTIFACT_STORE_URI_VAR]
-    del os.environ[Session.MLTE_CUSTOM_LIST_STORE_URI_VAR]
+    del os.environ[SessionStores.ENV_ARTIFACT_STORE_URI_VAR]
+    del os.environ[SessionStores.ENV_CUSTOM_LIST_STORE_URI_VAR]
 
 
 def test_no_context_setup():
@@ -107,7 +114,7 @@ def test_no_context_setup():
 
     with pytest.raises(RuntimeError):
         _ = s.context
-        _ = s.custom_list_store
+        _ = s.stores.custom_list_store
 
 
 def test_no_store_setup():
@@ -119,5 +126,5 @@ def test_no_store_setup():
     s = session()
 
     with pytest.raises(RuntimeError):
-        _ = s.artifact_store
-        _ = s.custom_list_store
+        _ = s.stores.artifact_store
+        _ = s.stores.custom_list_store

--- a/test/session/test_session.py
+++ b/test/session/test_session.py
@@ -121,10 +121,10 @@ def test_no_store_setup():
     model = "model"
     version = "v0.0.1"
 
-    set_context(model, version)
-
-    s = session()
-
     with pytest.raises(RuntimeError):
+        set_context(model, version)
+
+        s = session()
+
         _ = s.stores.artifact_store
         _ = s.stores.custom_list_store

--- a/test/validation/test_test_suite_validator.py
+++ b/test/validation/test_test_suite_validator.py
@@ -50,7 +50,7 @@ def test_success_defaults(store_with_context: tuple[ArtifactStore, Context]):
     """Tests that validator can load default TestSuite and all Evidence from current session, and validate it."""
     store, ctx = store_with_context
     set_context(model_id=ctx.model, version_id=ctx.version)
-    session()._set_artifact_store(store)
+    session().stores.set_artifact_store(store)
 
     test_suite = TestSuite.from_model(
         ArtifactModelFactory.make(ArtifactType.TEST_SUITE)


### PR DESCRIPTION
Resolves #632. More specifically:

 - Changes how the default (not sample) test catalog is created; instead of being an in-memory catalog by default, it gets stored in the same type of store configured for the library or backend.
 - Refactors how the different stores are set up, now the same code is used to set up stores for the library and the backend, reducing duplication and simplifying changes such as the default catalog one.