### PR TITLE
Feature/read only catalog

### DIFF
--- a/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
+++ b/mlte/frontend/nuxt-app/components/FormFields/quality-attributes.vue
@@ -3,6 +3,7 @@
     <UsaSelect
       v-model="qaCategory"
       :options="QACategoryOptions"
+      :disabled="props.disabled"
       @change="categoryChange(qaCategory)"
     >
       <template #label>
@@ -14,6 +15,7 @@
     <UsaSelect
       v-model="qualityAttribute"
       :options="selectedQAOptions"
+      :disabled="props.disabled"
       @change="emit('updateAttribute', $event.target.value)"
     >
       <template #label>
@@ -34,6 +36,10 @@ const props = defineProps({
   initialQualityAttribute: {
     type: String,
     required: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
   },
 });
 

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-edit.vue
@@ -45,6 +45,7 @@
       >
         <UsaCheckbox
           v-model="tag.selected"
+          :disabled="props.readOnly"
           @update:model-value="tagChange(tag.selected, tag.name)"
         >
           <template #default>
@@ -56,6 +57,7 @@
 
     <FormFieldsQualityAttributes
       :initial-quality-attribute="props.modelValue.quality_attribute"
+      :disabled="props.readOnly"
       @update-attribute="props.modelValue.quality_attribute = $event"
     >
       Quality Attribute Category
@@ -67,6 +69,7 @@
 
     <UsaTextarea
       v-model="modelValue.code"
+      :disabled="props.readOnly"
       style="resize: both; width: 30rem; max-width: 100%"
     >
       <template #label>
@@ -79,6 +82,7 @@
 
     <UsaTextarea
       v-model="modelValue.description"
+      :disabled="props.readOnly"
       style="resize: both; width: 30rem; max-width: 100%"
     >
       <template #label>
@@ -88,7 +92,7 @@
       <template #error-message>Not defined</template>
     </UsaTextarea>
 
-    <UsaTextInput v-model="modelValue.inputs">
+    <UsaTextInput v-model="modelValue.inputs" :disabled="props.readOnly">
       <template #label>
         Inputs
         <InfoIcon>
@@ -99,7 +103,7 @@
       <template #error-message>Not defined</template>
     </UsaTextInput>
 
-    <UsaTextInput v-model="modelValue.output">
+    <UsaTextInput v-model="modelValue.output" :disabled="props.readOnly">
       <template #label>
         Output
         <InfoIcon>
@@ -111,10 +115,17 @@
     </UsaTextInput>
 
     <div class="submit-footer">
-      <UsaButton class="primary-button" @click="emit('cancel')">
-        Cancel
-      </UsaButton>
-      <UsaButton class="primary-button" @click="submit"> Save </UsaButton>
+      <template v-if="props.readOnly">
+        <UsaButton class="primary-button" @click="emit('cancel', true)">
+          Back
+        </UsaButton>
+      </template>
+      <template v-else>
+        <UsaButton class="primary-button" @click="emit('cancel')">
+          Cancel
+        </UsaButton>
+        <UsaButton class="primary-button" @click="submit"> Save </UsaButton>
+      </template>
     </div>
   </div>
 </template>
@@ -129,6 +140,10 @@ const props = defineProps({
     required: true,
   },
   newEntryFlag: {
+    type: Boolean,
+    required: true,
+  },
+  readOnly: {
     type: Boolean,
     required: true,
   },

--- a/mlte/frontend/nuxt-app/components/TestCatalog/entry-list.vue
+++ b/mlte/frontend/nuxt-app/components/TestCatalog/entry-list.vue
@@ -5,7 +5,9 @@
         <th data-sortable scope="col" role="columnheader">Identifier</th>
         <th data-sortable scope="col" role="columnheader">Catalog</th>
         <th data-sortable scope="col" role="columnheader">Tags</th>
-        <th data-sortable scope="col" role="columnheader">Quality Attribute</th>
+        <th data-sortable scope="col" role="columnheader">
+          Quality Attribute Category
+        </th>
         <th data-sortable scope="col" role="columnheader">Actions</th>
       </tr>
     </thead>
@@ -22,33 +24,48 @@
           <span v-if="tagIndex + 1 < entry.tags.length">, </span>
         </span>
       </td>
-      <td>{{ entry.quality_attribute }}</td>
       <td>
-        <UsaButton class="secondary-button" @click="emit('editEntry', entry)">
-          Edit
-        </UsaButton>
-        <UsaButton
-          class="usa-button usa-button--secondary"
-          @click="
-            emit(
-              'deleteEntry',
-              entry.header.catalog_id,
-              entry.header.identifier,
-            )
-          "
-        >
-          Delete
-        </UsaButton>
+        {{ entry.quality_attribute }}
+      </td>
+      <td>
+        <template v-if="catalogLookup[entry.header.catalog_id].read_only">
+          <UsaButton class="secondary-button" @click="emit('editEntry', entry)">
+            View
+          </UsaButton>
+        </template>
+        <template v-else>
+          <UsaButton class="secondary-button" @click="emit('editEntry', entry)">
+            Edit
+          </UsaButton>
+          <UsaButton
+            class="usa-button usa-button--secondary"
+            @click="
+              emit(
+                'deleteEntry',
+                entry.header.catalog_id,
+                entry.header.identifier,
+              )
+            "
+          >
+            Delete
+          </UsaButton>
+        </template>
       </td>
     </tr>
   </table>
 </template>
 
 <script setup lang="ts">
+import type { PropType } from "vue";
+
 const emit = defineEmits(["addEntry", "editEntry", "deleteEntry"]);
 const props = defineProps({
   modelValue: {
     type: Array<TestCatalogEntry>,
+    required: true,
+  },
+  catalogLookup: {
+    type: Object as PropType<Dictionary<CatalogReply>>,
     required: true,
   },
 });


### PR DESCRIPTION
Builds on #711 

Addresses #481 

Adjusts read only test catalogs to display as readonly
- Change `edit` button to `view` in table
- Remove `delete` button in table
- Remove `save` button when viewing
- Change `cancel` button to `back` without confirmation when viewing
- Make all fields disabled when viewing a readonly entry