### PR TITLE
Feature/evidence less results

### DIFF
--- a/mlte/backend/core/config.py
+++ b/mlte/backend/core/config.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
     """The store URI string; defaults to in-memory store."""
 
     CATALOG_URIS: Dict[str, str] = {}
-    """The dict of catalog URI strings; defaults to one in-memory store."""
+    """The dict of catalog URI strings."""
 
     LOG_LEVEL: str = "ERROR"
     """The application log level; defaults to ERROR."""

--- a/mlte/evidence/types/image.py
+++ b/mlte/evidence/types/image.py
@@ -86,10 +86,7 @@ class Image(Evidence):
         :param info: The information to record.
         :return: The Validator that can be used.
         """
-        validator: Validator = Validator.build_validator(
-            info=info, input_types=[]
-        )
-        return validator
+        return Validator.build_info_validator(info)
 
     # Overriden.
     @classmethod

--- a/mlte/tests/test_case.py
+++ b/mlte/tests/test_case.py
@@ -57,16 +57,20 @@ class TestCase(Serializable):
 
         return self.measurement.evaluate(*args, **kwargs)
 
-    def validate(self, evidence: Evidence) -> Result:
+    def validate(self, evidence: Optional[Evidence]) -> Result:
         """Executes the configured validator with the given Evidence."""
         if self.validator is None:
             raise RuntimeError(
                 "Can't validate, no validator has been configured."
             )
 
-        return self.validator.validate(evidence)._with_evidence_metadata(
-            evidence.metadata
-        )
+        result = self.validator.validate(evidence)
+
+        # If evidence was received, add its metadata.
+        if evidence:
+            result = result._with_evidence_metadata(evidence.metadata)
+
+        return result
 
     # -------------------------------------------------------------------------
     # Model conversion.

--- a/mlte/validation/test_suite_validator.py
+++ b/mlte/validation/test_suite_validator.py
@@ -79,10 +79,16 @@ class TestSuiteValidator:
         :return: The results of the test validation.
         """
         # Check that all test cases have evidence to be validated.
-        for test_case_id in self.test_suite.test_cases.keys():
-            if test_case_id not in self.evidence:
+        for test_case_id, test_case in self.test_suite.test_cases.items():
+            # Make exception for info cases, where there is no bool exp to validate, but just info to be manually validated later.
+            is_info_case = (
+                test_case.validator
+                and not test_case.validator.bool_exp
+                and test_case.validator.info
+            )
+            if test_case_id not in self.evidence and not is_info_case:
                 raise RuntimeError(
-                    f"Test Case '{test_case_id}' does not have evidence that can be validated."
+                    f"Test Case '{test_case_id}' will be automatically validated, and does not have evidence that can be validated."
                 )
 
         # Validate and aggregate the results.

--- a/mlte/validation/test_suite_validator.py
+++ b/mlte/validation/test_suite_validator.py
@@ -94,8 +94,12 @@ class TestSuiteValidator:
         # Validate and aggregate the results.
         results: dict[str, Result] = {}
         for test_case_id, test_case in self.test_suite.test_cases.items():
-            results[test_case_id] = test_case.validate(
+            # Manage case where there is no evidence, typically for an info validator.
+            evidence = (
                 self.evidence[test_case_id]
+                if test_case_id in self.evidence
+                else None
             )
+            results[test_case_id] = test_case.validate(evidence)
 
         return TestResults(test_suite=self.test_suite, results=results)

--- a/mlte/validation/validator.py
+++ b/mlte/validation/validator.py
@@ -115,6 +115,19 @@ class Validator(Serializable):
         )
         return validator
 
+    @staticmethod
+    def build_info_validator(info: str) -> Validator:
+        """
+        Creates a genering Validator with no bool exp and with the given info.
+        Useful for validations that can't be automated but need to be recorded.
+        :param info: The information to record.
+        :return: The Validator that can be used.
+        """
+        validator: Validator = Validator.build_validator(
+            info=info, input_types=[]
+        )
+        return validator
+
     def validate(self, *args, **kwargs) -> Result:
         """
         Generates a result based on the arguments received, and the configured attributes in the Validator.

--- a/test/tests/test_test_suite.py
+++ b/test/tests/test_test_suite.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for TestSuite functionality.
-"""
+"""Unit tests for TestSuite functionality."""
 
 from __future__ import annotations
 
@@ -96,6 +94,7 @@ def test_save_invalid_qasids():
 def test_load_failure(
     store_with_context: tuple[ArtifactStore, Context]  # noqa
 ):
+    """Fail to load a suite that doesn't exist."""
     store, ctx = store_with_context
     with pytest.raises(RuntimeError):
         _ = TestSuite.load_with("test_suite", context=ctx, store=store)

--- a/test/validation/test_test_suite_validator.py
+++ b/test/validation/test_test_suite_validator.py
@@ -9,10 +9,14 @@ import pytest
 from mlte.artifact.type import ArtifactType
 from mlte.context.context import Context
 from mlte.evidence.types.integer import Integer
+from mlte.evidence.types.real import Real
+from mlte.measurement.storage.local_object_size import LocalObjectSize
 from mlte.session.session import session, set_context
 from mlte.store.artifact.store import ArtifactStore
+from mlte.tests.test_case import TestCase
 from mlte.tests.test_suite import TestSuite
 from mlte.validation.test_suite_validator import TestSuiteValidator
+from mlte.validation.validator import Validator
 from test.evidence.types.helper import get_sample_evidence_metadata
 from test.fixture.artifact import ArtifactModelFactory
 
@@ -68,3 +72,56 @@ def test_success_defaults(store_with_context: tuple[ArtifactStore, Context]):
     assert test_results is not None
     assert test_results.test_suite == test_suite
     assert len(test_results.results) == 1
+
+
+def test_suite_validate():
+    """Test that we can validate with regular, info, and info+no evidence cases."""
+    test_suite = TestSuite(
+        test_cases=[
+            TestCase(
+                identifier="case1",
+                goal="Check storage consumption",
+                quality_scenarios=["qas1"],
+                validator=LocalObjectSize.get_output_type().less_than(
+                    150000000
+                ),
+                measurement=LocalObjectSize("model size"),
+            ),
+            TestCase(
+                identifier="case2",
+                goal="Check storage consumption",
+                quality_scenarios=["qas2"],
+                validator=Validator.build_info_validator(
+                    "This will have evidence BUT has to be manually validated"
+                ),
+            ),
+            TestCase(
+                identifier="case3",
+                goal="Check storage consumption",
+                quality_scenarios=["qas3"],
+                validator=Validator.build_info_validator(
+                    "This will have no evidence and has to be manually validated"
+                ),
+            ),
+        ]
+    )
+
+    test_suite_validator = TestSuiteValidator(test_suite)
+
+    m = get_sample_evidence_metadata(test_case_id="case1")
+    i = Real(1.0).with_metadata(m)
+    test_suite_validator.add_evidence(i)
+
+    m = get_sample_evidence_metadata(test_case_id="case2")
+    i = Real(1.0).with_metadata(m)
+    test_suite_validator.add_evidence(i)
+
+    test_results = test_suite_validator.validate()
+
+    assert test_results is not None
+    assert len(test_results.results) == 3
+    for case_id, result in test_results.results.items():
+        if case_id == "case1":
+            assert str(result) == "Success"
+        else:
+            assert str(result) == "Info"


### PR DESCRIPTION
Resolves #709. More specifically:
 - Modifies TestSuiteValidator to still validate TestCases that don't have associated Evidence, but ONLY if the associated validator generates an Info result (meaning it has to be manually validated anyway, with or without additional Evidence attached).
 - Adds explicit generic method to Validator, build_info_validator(info: str), which generates a mostly empty Validator that always generates an Informational result with the provided text, to be used directly in the specification of a TestCase if needed.
 - Modified TestCase.validate() method to work even if no evidence is received.