### PR TITLE
Fixes Consistency of URI Env Var Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Before most operations can be done on `MLTE`, a context and artifact store need 
 ```python
 from mlte.session import set_context, set_store
 ```
-``set_context()`` indicates the model and version being used for the script, and can be any string. ``set_store()`` indicates the location of the artifact store being used, with four store type options described in the <a href="https://mlte.readthedocs.io/en/latest/using_mlte/" target="_blank">documentation</a>. The MLTE context and artifact store can alternatively be set by environment variables before starting the script (``MLTE_CONTEXT_MODEL``, ``MLTE_CONTEXT_VERSION``, ``MLTE_ARTIFACT_STORE_URI``, and ``MLTE_CUSTOM_LIST_STORE_URI_VAR``), and can later be overridden using the set methods above.
+``set_context()`` indicates the model and version being used for the script, and can be any string. ``set_store()`` indicates the location of the artifact store being used, with four store type options described in the <a href="https://mlte.readthedocs.io/en/latest/using_mlte/" target="_blank">documentation</a>. The MLTE context and  store can alternatively be set by environment variables before starting the script (``MLTE_CONTEXT_MODEL``, ``MLTE_CONTEXT_VERSION``, and ``MLTE_STORE_URI``), and can later be overridden using the set methods above.
 
 ## Next Steps
 

--- a/docs/docs/using_mlte.md
+++ b/docs/docs/using_mlte.md
@@ -124,12 +124,12 @@ They are described and used in the following way:
 
 - ``set_context("model_name", "model_version")``: this command indicates the model and version you will be working on for the rest of the script. It is mostly used to point to the proper location in the store when saving and loading artifacts. The model name and version can be any string.
 
-- ``set_store("store_uri")``: this command indicates the location of the artifact store you will be using for the rest of the script. There are four store types, with the structure described in the [Store URIs](#store-uris) section.
+- ``set_store("store_uri")``: this command indicates the location of the store you will be using for the rest of the script. There are four store types, with the structure described in the [Store URIs](#store-uris) section.
 
 Alternatively, these two things can also be set by environment variables before starting your Python script. If needed, these values can later be overriden in the script usng the set methods above.
 
 - ``MLTE_CONTEXT_MODEL`` and ``MLTE_CONTEXT_VERSION`` to set the model and version.
-- ``MLTE_ARTIFACT_STORE_URI`` to set the artifact store URI.
+- ``MLTE_STORE_URI`` to set the store URI.
 
 ## Negotiate Model Quality Requirements
 

--- a/mlte/session/session_stores.py
+++ b/mlte/session/session_stores.py
@@ -1,10 +1,8 @@
 """Manages current session info about stores."""
 
-import os
 from typing import Optional
 
 from mlte.store.artifact import factory as artifact_store_factory
-from mlte.store.artifact.factory import create_artifact_store
 from mlte.store.artifact.store import ArtifactStore
 from mlte.store.catalog.catalog_group import CatalogStoreGroup
 from mlte.store.catalog.sample_catalog import SampleCatalog
@@ -12,7 +10,6 @@ from mlte.store.catalog.store import CatalogStore
 from mlte.store.custom_list.initial_custom_lists import InitialCustomLists
 from mlte.store.custom_list.store import CustomListStore
 from mlte.store.user import factory as user_store_factory
-from mlte.store.user.factory import create_user_store
 from mlte.store.user.store import UserStore
 
 
@@ -20,15 +17,6 @@ class SessionStores:
     """
     Contains the store sessions currently being used.
     """
-
-    ENV_ARTIFACT_STORE_URI_VAR = "MLTE_ARTIFACT_STORE_URI"
-    """Environment variable to get the artifact store URI from, if needed."""
-
-    ENV_CUSTOM_LIST_STORE_URI_VAR = "MLTE_CUSTOM_LIST_STORE_URI"
-    """Environment variable to get the custom list store URI from, if needed."""
-
-    ENV_USER_STORE_URI_VAR = "MLTE_CUSTOM_LIST_STORE_URI"
-    """Environment variable to get the custom list store URI from, if needed."""
 
     DEFAULT_CATALOG_STORE_ID = "local"
     """Name of the default catalog store."""
@@ -75,55 +63,28 @@ class SessionStores:
     @property
     def artifact_store(self) -> ArtifactStore:
         """Get the session artifact store."""
-        if self._artifact_store is None:
-            # If the URI has not been manually set, get it from environment.
-            store_uri = self._get_env_var(self.ENV_ARTIFACT_STORE_URI_VAR)
-            if store_uri:
-                self._artifact_store = create_artifact_store(store_uri)
-            else:
-                raise RuntimeError(
-                    "Must initialize artifact store, either manually or through environment variables."
-                )
+        if not self._artifact_store:
+            raise RuntimeError("Store was not properly set up.")
         return self._artifact_store
 
     @property
     def custom_list_store(self) -> CustomListStore:
         """Get the session custom list store."""
-        if self._custom_list_store is None:
-            # If the store URI has not been manually set, get it from environment.
-            store_uri = self._get_env_var(self.ENV_CUSTOM_LIST_STORE_URI_VAR)
-            if store_uri:
-                self._custom_list_store = (
-                    InitialCustomLists.setup_custom_list_store(store_uri)
-                )
-            else:
-                raise RuntimeError(
-                    "Must initialize custom list store, either manually or through environment variables."
-                )
+        if not self._custom_list_store:
+            raise RuntimeError("Store was not properly set up.")
         return self._custom_list_store
 
     @property
     def user_store(self) -> UserStore:
         """Get session user store."""
-        if self._user_store is None:
-            # If the store URI has not been manually set, get it from environment.
-            store_uri = self._get_env_var(self.ENV_USER_STORE_URI_VAR)
-            if store_uri:
-                self._user_store = create_user_store(store_uri)
-            else:
-                raise RuntimeError(
-                    "Must initialize user store, either manually or through environment variables."
-                )
+        if not self._user_store:
+            raise RuntimeError("Store was not properly set up.")
         return self._user_store
 
     @property
     def catalog_stores(self) -> CatalogStoreGroup:
         """Get all catalog stores."""
         return self._catalog_stores
-
-    def _get_env_var(self, env_var: str) -> Optional[str]:
-        """Get env var or return none if does not exist."""
-        return os.environ.get(env_var, None)
 
 
 def setup_stores(
@@ -144,12 +105,12 @@ def setup_stores(
     artifact_store = artifact_store_factory.create_artifact_store(stores_uri)
     stores.set_artifact_store(artifact_store)
 
-    # Initialize the backing user store instance. Assume same store as artifact one for now.
+    # Initialize the backing user store instance.
     if set_user_store:
         user_store = user_store_factory.create_user_store(stores_uri)
         stores.set_user_store(user_store)
 
-    # Initialize the backing custom list store instance. Assume same store as artifact one for now.
+    # Initialize the backing custom list store instance.
     custom_list_store = InitialCustomLists.setup_custom_list_store(stores_uri)
     stores.set_custom_list_store(custom_list_store)
 

--- a/mlte/store/custom_list/factory.py
+++ b/mlte/store/custom_list/factory.py
@@ -28,5 +28,5 @@ def create_custom_list_store(uri: str) -> CustomListStore:
     # return HttpCustomListStore(uri=parsed_uri)
     else:
         raise Exception(
-            f"Store can't be created, unknown or unsupported URI prefix received for uri {parsed_uri}"
+            f"Custom list store can't be created, unknown or unsupported URI prefix received for uri {parsed_uri}"
         )

--- a/test/session/test_session.py
+++ b/test/session/test_session.py
@@ -1,8 +1,4 @@
-"""
-test/session/test_session.py
-
-Unit tests for global session management.
-"""
+"""Unit tests for global session management."""
 
 import os
 
@@ -10,7 +6,6 @@ import pytest
 
 from mlte.session import session, set_context, set_store
 from mlte.session.session import Session, add_catalog_store, reset_session
-from mlte.session.session_stores import SessionStores
 from mlte.store.artifact.store import ArtifactStore
 from mlte.store.base import StoreType, StoreURI
 
@@ -82,27 +77,22 @@ def test_eager_context_creation(
 def test_environment_vars():
     model = "model"
     version = "v0.0.1"
-    artifact_store_uri = StoreURI.create_uri_string(StoreType.LOCAL_MEMORY)
-    custom_list_store_uri = StoreURI.create_uri_string(StoreType.LOCAL_MEMORY)
+    store_uri = StoreURI.create_uri_string(StoreType.LOCAL_MEMORY)
 
-    os.environ[Session.MLTE_CONTEXT_MODEL_VAR] = model
-    os.environ[Session.MLTE_CONTEXT_VERSION_VAR] = version
-    os.environ[SessionStores.ENV_ARTIFACT_STORE_URI_VAR] = artifact_store_uri
-    os.environ[SessionStores.ENV_CUSTOM_LIST_STORE_URI_VAR] = (
-        custom_list_store_uri
-    )
+    os.environ[Session.ENV_CONTEXT_MODEL_VAR] = model
+    os.environ[Session.ENV_CONTEXT_VERSION_VAR] = version
+    os.environ[Session.ENV_STORE_URI_VAR] = store_uri
 
     s = session()
 
     assert s.context.model == model
     assert s.context.version == version
-    assert s.stores.artifact_store.uri.uri == artifact_store_uri
-    assert s.stores.custom_list_store.uri.uri == custom_list_store_uri
+    assert s.stores.artifact_store.uri.uri == store_uri
+    assert s.stores.custom_list_store.uri.uri == store_uri
 
-    del os.environ[Session.MLTE_CONTEXT_MODEL_VAR]
-    del os.environ[Session.MLTE_CONTEXT_VERSION_VAR]
-    del os.environ[SessionStores.ENV_ARTIFACT_STORE_URI_VAR]
-    del os.environ[SessionStores.ENV_CUSTOM_LIST_STORE_URI_VAR]
+    del os.environ[Session.ENV_CONTEXT_MODEL_VAR]
+    del os.environ[Session.ENV_CONTEXT_VERSION_VAR]
+    del os.environ[Session.ENV_STORE_URI_VAR]
 
 
 def test_no_context_setup():

--- a/test/validation/test_test_suite_validator.py
+++ b/test/validation/test_test_suite_validator.py
@@ -12,6 +12,7 @@ from mlte.evidence.types.integer import Integer
 from mlte.evidence.types.real import Real
 from mlte.measurement.storage.local_object_size import LocalObjectSize
 from mlte.session.session import session, set_context
+from mlte.session.session_stores import SessionStores
 from mlte.store.artifact.store import ArtifactStore
 from mlte.tests.test_case import TestCase
 from mlte.tests.test_suite import TestSuite
@@ -54,6 +55,7 @@ def test_success_defaults(store_with_context: tuple[ArtifactStore, Context]):
     """Tests that validator can load default TestSuite and all Evidence from current session, and validate it."""
     store, ctx = store_with_context
     set_context(model_id=ctx.model, version_id=ctx.version)
+    session()._stores = SessionStores()
     session().stores.set_artifact_store(store)
 
     test_suite = TestSuite.from_model(


### PR DESCRIPTION
Resolves #720. More specifically: 
 - For the optional env vars that can be used to set up context/store when using the MLTE as a package/library, unified all store related vars into one, MLTE_STORE_URI, as all the rest of the codebase assumes all stores use the same URI for all stores (except possibly for the catalog, if additional ones are configured). Now this is consistent with how store URIs are used internally.
 - Also moved this env handling to the Session class, at the same level as the context (model/version) env handling, since these env vars are targeted to the library use, not the backend (which has separate vars set for Docker).