### PR TITLE
Improve admin error handling

### DIFF
--- a/mlte/frontend/nuxt-app/composables/http-error-handling.ts
+++ b/mlte/frontend/nuxt-app/composables/http-error-handling.ts
@@ -6,7 +6,7 @@ export function requestErrorAlert() {
 
 export function handleHttpError(
   errorCode: number,
-  errorMessage: string | null,
+  errorMessage: string | null = null,
 ) {
   if (errorCode === 400) {
     http400(errorMessage);

--- a/mlte/frontend/nuxt-app/middleware/auth.global.ts
+++ b/mlte/frontend/nuxt-app/middleware/auth.global.ts
@@ -1,8 +1,20 @@
 export default defineNuxtRouteMiddleware((from) => {
   const token = useCookie("token");
+
+  // Handle unlogged in user, and logged in user going to login page
   if (!token.value && from.fullPath !== "/login-page/") {
     return navigateTo("/login-page/");
   } else if (token.value && from.fullPath === "/login-page/") {
+    return navigateTo("/");
+  }
+
+  // Handle non-admin accessing admin pages
+  const role = useCookie("userRole");
+  if (
+    token.value &&
+    role.value !== "admin" &&
+    from.fullPath.substring(0, 7) == "/admin/"
+  ) {
     return navigateTo("/");
   }
 });


### PR DESCRIPTION
Resolves #433 

Previously would handle the admin auth by catching the 403 error from the backend, and redirecting off of that. Now it will catch the nav to a `/admin` page before loading it and just redirecting straight to the homepage. This case will no longer have an error message, because showing the error before nav causes the admin page to still be loaded in the background