### PR TITLE
Refactor/parallel ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Define os matrix
         id: os_matrix
-        run: echo 'os_matrix=$OS_VERSIONS' >> "$GITHUB_OUTPUT"
+        run: echo "os_matrix=$OS_VERSIONS" >> "$GITHUB_OUTPUT"
       - name: Define Python version matrix
         id: py_ver_matrix
-        run: echo 'py_ver_matrix=$PYTHON_VERSIONS' >> "$GITHUB_OUTPUT"
+        run: echo "py_ver_matrix=$PYTHON_VERSIONS" >> "$GITHUB_OUTPUT"
 
   library-backend:
     needs: define-matrix


### PR DESCRIPTION
Resolves #778 

Separated frontend and demo jobs out from the main. Added a first setup job that sets the env variables as json values because you can't set anything except strings in the env vars. It is one of the official way to handle this situation from the github docs. Went from 17-20min runs down to about 10mins so pretty solid improvement

