### PR TITLE
Bug Not Overwriting Artifacts

### DIFF
--- a/mlte/store/artifact/store_session.py
+++ b/mlte/store/artifact/store_session.py
@@ -173,7 +173,7 @@ class ArtifactMapper(ResourceMapper):
         """
         artifact_id = artifact.header.identifier
         try:
-            artifact = self.read(artifact_id, (model_id, version_id))
+            _ = self.read(artifact_id, (model_id, version_id))
             if not force:
                 # If it exists and we are not "forcing" (overriting/editing), complain it already exists.
                 raise errors.ErrorAlreadyExists(

--- a/test/negotiation/test_artifact.py
+++ b/test/negotiation/test_artifact.py
@@ -15,6 +15,7 @@ from mlte.artifact.type import ArtifactType
 from mlte.context.context import Context
 from mlte.negotiation import qas
 from mlte.negotiation.artifact import NegotiationCard
+from mlte.negotiation.model import DataDescriptor
 from mlte.negotiation.qas import QASDescriptor
 from mlte.store.artifact.store import ArtifactStore
 from test.fixture.artifact import ArtifactModelFactory
@@ -80,12 +81,17 @@ def test_save_overwrite(
     card = get_sample_negotiation_card()
     card.save_with(ctx, store)
 
+    # Change card.
+    card.data.append(DataDescriptor(description="New data descriptor"))
+
     # Write without `force` fails
     with pytest.raises(errors.ErrorAlreadyExists):
         card.save_with(ctx, store)
 
     # Force write succeeds
-    card.save_with(ctx, store, force=True)
+    read_card_model = card.save_with(ctx, store, force=True)
+    read_card = NegotiationCard.from_model(read_card_model)
+    assert card == read_card
 
 
 def test_qas_id_generation():


### PR DESCRIPTION
Resolves #808.

Fixed bug in write method, which was not overwritingartifacts properly due to improper read that was ignoring changes. Also fixed unit test to detect this.