### PR TITLE
ReadTheDocs: updating to Ubuntu 24.04 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   jobs:


### PR DESCRIPTION
Addresses #859 by updating to Ubuntu 24.0.4 since 20.04 is being deprecated in 07/2026. Can't really be tested until it is in the repo and triggers a ReadTheDocs regeneration.