### PR TITLE
Feature/user messages

### DIFF
--- a/demo/GardenBuddy/evidence/multiple_ranksums.py
+++ b/demo/GardenBuddy/evidence/multiple_ranksums.py
@@ -39,7 +39,9 @@ class MultipleRanksums(ExternalEvidence):
         return MultipleRanksums(np.asarray(json_["array"]), json_["num_pops"])
 
     @classmethod
-    def all_p_values_greater_or_equal_than(cls, threshold: float) -> Validator:
+    def all_p_values_greater_or_equal_than(
+        cls, threshold: float, success: str = "", failure: str = ""
+    ) -> Validator:
         """
         Checks if the p-value for multiple ranksums is below given threshold.
 
@@ -52,8 +54,10 @@ class MultipleRanksums(ExternalEvidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold],
-            success=f"All p-values are equal to or over threshold {threshold}",
-            failure=f"One or more p-values are below threshold {threshold}",
+            success=success,
+            failure=failure,
+            default_success=f"All p-values are equal to or over threshold {threshold}",
+            default_failure=f"One or more p-values are below threshold {threshold}",
             input_types=[MultipleRanksums],
         )
         return validator

--- a/demo/GardenBuddy/utils/validators.py
+++ b/demo/GardenBuddy/utils/validators.py
@@ -8,7 +8,9 @@ from mlte.evidence.types.array import Array
 from mlte.validation.validator import Validator
 
 
-def all_accuracies_more_or_equal_than(threshold: float) -> Validator:
+def all_accuracies_more_or_equal_than(
+    threshold: float, success: str = "", failure: str = ""
+) -> Validator:
     """
     Checks if the accuracy for multiple populations is fair by checking if all of them are over the given threshold.
 
@@ -20,14 +22,18 @@ def all_accuracies_more_or_equal_than(threshold: float) -> Validator:
     ) == len(value.array)
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"All accuracies are equal to or over threshold {threshold}",
-        failure=f"One or more accuracies are below threshold {threshold}",
+        success=success,
+        failure=failure,
+        default_success=f"All accuracies are equal to or over threshold {threshold}",
+        default_failure=f"One or more accuracies are below threshold {threshold}",
         input_types=[Array],
     )
     return validator
 
 
-def p_value_greater_or_equal_to(threshold: float) -> Validator:
+def p_value_greater_or_equal_to(
+    threshold: float, success: str = "", failure: str = ""
+) -> Validator:
     """
     A RankSums array is an array with the results of the ranksums function (stat on first pos, p-value on second).
 
@@ -40,8 +46,10 @@ def p_value_greater_or_equal_to(threshold: float) -> Validator:
     )
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"P-Value is greater or equal to {threshold}",
-        failure=f"P-Value is less than threshold {threshold}",
+        success=success,
+        failure=failure,
+        default_success=f"P-Value is greater or equal to {threshold}",
+        default_failure=f"P-Value is less than threshold {threshold}",
         input_types=[Array],
     )
     return validator

--- a/demo/GradientClimber/utils/validators.py
+++ b/demo/GradientClimber/utils/validators.py
@@ -8,7 +8,9 @@ from mlte.evidence.types.array import Array
 from mlte.validation.validator import Validator
 
 
-def passed_percent_more_or_equal_then(threshold: float) -> Validator:
+def passed_percent_more_or_equal_then(
+    threshold: float, success: str = "", failure: str = ""
+) -> Validator:
     """
     Checks if an array of pass/fail values have pass above a given threshold.
 
@@ -21,8 +23,10 @@ def passed_percent_more_or_equal_then(threshold: float) -> Validator:
     )
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"The fraction of passes is at or over threshold {threshold}",
-        failure=f"The fraction of passes is below threshold  {threshold}",
+        success=success,
+        failure=failure,
+        default_success=f"The fraction of passes is at or over threshold {threshold}",
+        default_failure=f"The fraction of passes is below threshold  {threshold}",
         input_types=[Array],
     )
     return validator

--- a/demo/ReviewPro/utils/validators.py
+++ b/demo/ReviewPro/utils/validators.py
@@ -8,7 +8,9 @@ from mlte.evidence.types.array import Array
 from mlte.validation.validator import Validator
 
 
-def all_nums_less_than(threshold: float, units: str) -> Validator:
+def all_nums_less_than(
+    threshold: float, units: str, success: str = "", failure: str = ""
+) -> Validator:
     """
     Checks if all the numbers in the array are equal to or below a given threshold.
 
@@ -20,14 +22,18 @@ def all_nums_less_than(threshold: float, units: str) -> Validator:
     ) == len(value.array)
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"All numbers provided are less than or equal to threshold {threshold}{units}",
-        failure=f"One or more numbers are above {threshold}{units}",
+        success=success,
+        failure=failure,
+        default_success=f"All numbers provided are less than or equal to threshold {threshold}{units}",
+        default_failure=f"One or more numbers are above {threshold}{units}",
         input_types=[Array],
     )
     return validator
 
 
-def p_not_signifigant(threshold: float) -> Validator:
+def p_not_signifigant(
+    threshold: float, success: str = "", failure: str = ""
+) -> Validator:
     """
     Checks if all the numbers in the array are equal to or below a given threshold.
 
@@ -39,14 +45,18 @@ def p_not_signifigant(threshold: float) -> Validator:
     ) == len(value.array)
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"All p-values provided are not signifigant at a threshold of p < {threshold}",
-        failure=f"One or more p-values indicate that a result may be signifigant at p < {threshold}",
+        success=success,
+        failure=failure,
+        default_success=f"All p-values provided are not signifigant at a threshold of p < {threshold}",
+        default_failure=f"One or more p-values indicate that a result may be signifigant at p < {threshold}",
         input_types=[Array],
     )
     return validator
 
 
-def p_value_greater_or_equal_to(threshold: float) -> Validator:
+def p_value_greater_or_equal_to(
+    threshold: float, success: str = "", failure: str = ""
+) -> Validator:
     """
     A RankSums array is an array with the results of the ranksums function (stat on first pos, p-value on second).
 
@@ -59,8 +69,10 @@ def p_value_greater_or_equal_to(threshold: float) -> Validator:
     )
     validator: Validator = Validator.build_validator(
         bool_exp=bool_exp,
-        success=f"P-Value is greater or equal to {threshold}",
-        failure=f"P-Value is less than threshold {threshold}",
+        success=success,
+        failure=failure,
+        default_success=f"P-Value is greater or equal to {threshold}",
+        default_failure=f"P-Value is less than threshold {threshold}",
         input_types=[Array],
     )
     return validator

--- a/demo/simple/utils/confusion_matrix.py
+++ b/demo/simple/utils/confusion_matrix.py
@@ -47,7 +47,9 @@ class ConfusionMatrix(ExternalEvidence):
         return int(count)
 
     @classmethod
-    def misclassification_count_less_than(cls, threshold: int) -> Validator:
+    def misclassification_count_less_than(
+        cls, threshold: int, success: str = "", failure: str = ""
+    ) -> Validator:
         """
         Creates a Validator to check if missclassification is less or equal than the given threshold.
 
@@ -61,8 +63,10 @@ class ConfusionMatrix(ExternalEvidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold],
-            success=f"Misclass count is less than threshold {threshold}",
-            failure=f"Misclassification count exceeds threshold {threshold}",
+            success=success,
+            failure=failure,
+            default_success=f"Misclass count is less than threshold {threshold}",
+            default_failure=f"Misclassification count exceeds threshold {threshold}",
             input_types=[ConfusionMatrix],
         )
         return validator

--- a/mlte/evidence/types/integer.py
+++ b/mlte/evidence/types/integer.py
@@ -83,7 +83,11 @@ class Integer(Evidence):
 
     @classmethod
     def less_than(
-        cls, threshold: int, unit: Optional[Unit] = None
+        cls,
+        threshold: int,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if integer is strictly less than `value`.
@@ -99,15 +103,21 @@ class Integer(Evidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold_w_unit],
-            success=f"Integer magnitude is less than threshold {quantity_to_str(threshold_w_unit)})",
-            failure=f"Integer magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Integer magnitude is less than threshold {quantity_to_str(threshold_w_unit)})",
+            default_failure=f"Integer magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Integer],
         )
         return validator
 
     @classmethod
     def less_or_equal_to(
-        cls, threshold: int, unit: Optional[Unit] = None
+        cls,
+        threshold: int,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if integer is less than or equal to `value`.
@@ -123,8 +133,10 @@ class Integer(Evidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold_w_unit],
-            success=f"Integer magnitude is less than or equal to threshold {quantity_to_str(threshold_w_unit)}",
-            failure=f"Integer magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Integer magnitude is less than or equal to threshold {quantity_to_str(threshold_w_unit)}",
+            default_failure=f"Integer magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Integer],
         )
         return validator

--- a/mlte/evidence/types/real.py
+++ b/mlte/evidence/types/real.py
@@ -84,7 +84,11 @@ class Real(Evidence):
 
     @classmethod
     def less_than(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if real is strictly less than `threshold`.
@@ -99,15 +103,21 @@ class Real(Evidence):
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"Real magnitude is less than threshold {quantity_to_str(threshold_w_unit)}",
-            failure=f"Real magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Real magnitude is less than threshold {quantity_to_str(threshold_w_unit)}",
+            default_failure=f"Real magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Real],
         )
         return validator
 
     @classmethod
     def less_or_equal_to(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if real is less than or equal to `threshold`.
@@ -122,15 +132,21 @@ class Real(Evidence):
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"Real magnitude is less than or equal to threshold {quantity_to_str(threshold_w_unit)}",
-            failure=f"Real magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Real magnitude is less than or equal to threshold {quantity_to_str(threshold_w_unit)}",
+            default_failure=f"Real magnitude exceeds threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Real],
         )
         return validator
 
     @classmethod
     def greater_than(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if real is strictly greater than `threshold`.
@@ -145,15 +161,21 @@ class Real(Evidence):
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"Real magnitude is greater than threshold {quantity_to_str(threshold_w_unit)}",
-            failure=f"Real magnitude is below threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Real magnitude is greater than threshold {quantity_to_str(threshold_w_unit)}",
+            default_failure=f"Real magnitude is below threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Real],
         )
         return validator
 
     @classmethod
     def greater_or_equal_to(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Determine if real is greater than or equal to `threshold`.
@@ -168,8 +190,10 @@ class Real(Evidence):
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"Real magnitude is greater than or equal to threshold {quantity_to_str(threshold_w_unit)}",
-            failure=f"Real magnitude is below threshold {quantity_to_str(threshold_w_unit)}",
+            success=success,
+            failure=failure,
+            default_success=f"Real magnitude is greater than or equal to threshold {quantity_to_str(threshold_w_unit)}",
+            default_failure=f"Real magnitude is below threshold {quantity_to_str(threshold_w_unit)}",
             input_types=[Real],
         )
         return validator

--- a/mlte/evidence/types/string.py
+++ b/mlte/evidence/types/string.py
@@ -51,29 +51,37 @@ class String(Evidence):
         return String(value=body.value.string).with_metadata(body.metadata)  # type: ignore
 
     @classmethod
-    def contains(cls, substring: str) -> Validator:
+    def contains(
+        cls, substring: str, success: str = "", failure: str = ""
+    ) -> Validator:
         """Checks if the given string is in this one."""
         bool_exp: Callable[[String], bool] = (
             lambda value: substring in value.value
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"Substring '{substring}' is contained in the string value.",
-            failure=f"Substring '{substring}' is not contained in the string value.",
+            success=success,
+            failure=failure,
+            default_success=f"Substring '{substring}' is contained in the string value.",
+            default_failure=f"Substring '{substring}' is not contained in the string value.",
             input_types=[String],
         )
         return validator
 
     @classmethod
-    def equal_to(cls, other_string: str) -> Validator:
+    def equal_to(
+        cls, other_string: str, success: str = "", failure: str = ""
+    ) -> Validator:
         """Checks if the given string is the same as this one in value."""
         bool_exp: Callable[[String], bool] = (
             lambda value: other_string == value.value
         )
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
-            success=f"String '{other_string}' is equal to the internal string value.",
-            failure=f"String '{other_string}' is not equal to the internal string value.",
+            success=success,
+            failure=failure,
+            default_success=f"String '{other_string}' is equal to the internal string value.",
+            default_failure=f"String '{other_string}' is not equal to the internal string value.",
             input_types=[String],
         )
         return validator

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
@@ -953,6 +953,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -1009,6 +1017,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/report/v0.0.1/schema.json
@@ -710,6 +710,10 @@
           "title": "Message",
           "type": "string"
         },
+        "additional_data": {
+          "title": "Additional Data",
+          "type": "string"
+        },
         "evidence_metadata": {
           "anyOf": [
             {
@@ -724,6 +728,7 @@
       "required": [
         "type",
         "message",
+        "additional_data",
         "evidence_metadata"
       ],
       "title": "ResultModel",

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/results/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/results/v0.0.1/schema.json
@@ -56,6 +56,10 @@
           "title": "Message",
           "type": "string"
         },
+        "additional_data": {
+          "title": "Additional Data",
+          "type": "string"
+        },
         "evidence_metadata": {
           "anyOf": [
             {
@@ -70,6 +74,7 @@
       "required": [
         "type",
         "message",
+        "additional_data",
         "evidence_metadata"
       ],
       "title": "ResultModel",

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/results/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/results/v0.0.1/schema.json
@@ -215,6 +215,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -271,6 +279,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/frontend/nuxt-app/assets/schema/artifact/tests/v0.0.1/schema.json
+++ b/mlte/frontend/nuxt-app/assets/schema/artifact/tests/v0.0.1/schema.json
@@ -141,6 +141,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -197,6 +205,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/measurement/common.py
+++ b/mlte/measurement/common.py
@@ -87,7 +87,7 @@ class CommonStatistics(ExternalEvidence):
         cls, threshold: float, unit: Optional[Unit] = None
     ) -> Validator:
         """
-        Construct and invoke a validator for maximum memory utilization.
+        Construct and invoke a validator for maximum resource utilization.
 
         :param threshold: The threshold value for maximum utilization
         :param unit: the unit the threshold comes in, as a value from Units; defaults to DEFAULT_UNIT
@@ -116,7 +116,7 @@ class CommonStatistics(ExternalEvidence):
         cls, threshold: float, unit: Optional[Unit] = None
     ) -> Validator:
         """
-        Construct and invoke a validator for average memory utilization.
+        Construct and invoke a validator for average resource utilization.
 
         :param threshold: The threshold value for average utilization, in KB
         :param unit: the unit the threshold comes in, as a value from Units; defaults to Units.kilobyte

--- a/mlte/measurement/common.py
+++ b/mlte/measurement/common.py
@@ -84,7 +84,11 @@ class CommonStatistics(ExternalEvidence):
 
     @classmethod
     def max_utilization_less_than(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Construct and invoke a validator for maximum resource utilization.
@@ -105,15 +109,21 @@ class CommonStatistics(ExternalEvidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold_w_unit],
-            success=f"Maximum utilization below threshold {threshold_w_unit}",
-            failure=f"Maximum utilization exceeds threshold {threshold_w_unit}",
+            success=success,
+            failure=failure,
+            default_success=f"Maximum utilization below threshold {threshold_w_unit}",
+            default_failure=f"Maximum utilization exceeds threshold {threshold_w_unit}",
             input_types=[cls],
         )
         return validator
 
     @classmethod
     def average_utilization_less_than(
-        cls, threshold: float, unit: Optional[Unit] = None
+        cls,
+        threshold: float,
+        unit: Optional[Unit] = None,
+        success: str = "",
+        failure: str = "",
     ) -> Validator:
         """
         Construct and invoke a validator for average resource utilization.
@@ -135,8 +145,10 @@ class CommonStatistics(ExternalEvidence):
         validator: Validator = Validator.build_validator(
             bool_exp=bool_exp,
             thresholds=[threshold_w_unit],
-            success=f"Average utilization below threshold {threshold_w_unit}",
-            failure=f"Average utilization exceeds threshold {threshold_w_unit}",
+            success=success,
+            failure=failure,
+            default_success=f"Average utilization below threshold {threshold_w_unit}",
+            default_failure=f"Average utilization exceeds threshold {threshold_w_unit}",
             input_types=[cls],
         )
         return validator

--- a/mlte/results/model.py
+++ b/mlte/results/model.py
@@ -17,6 +17,9 @@ class ResultModel(BaseModel):
     message: str
     """The message indicating the reason for status."""
 
+    additional_data: str
+    """Additional details that we don't want to put up front in the message, if any."""
+
     evidence_metadata: Optional[EvidenceMetadata]
     """Metadata about the evidence this came from."""
 

--- a/mlte/results/result.py
+++ b/mlte/results/result.py
@@ -23,11 +23,14 @@ class Result(ABC):
         """Define the interface for all concrete Result."""
         return meta.has_callables(subclass, "__bool__", "__str__")
 
-    def __init__(self, message: str):
+    def __init__(self, message: str, additional_data: str = ""):
         """Initialize a Result instance."""
 
         self.message = message
         """The message indicating the reason for status."""
+
+        self.additional_data = additional_data
+        """Additional details to complement the message, if any."""
 
         self.evidence_metadata: Optional[EvidenceMetadata] = None
         """
@@ -61,6 +64,7 @@ class Result(ABC):
         return ResultModel(
             type=f"{self}",
             message=self.message,
+            additional_data=self.additional_data,
             evidence_metadata=self.evidence_metadata,
         )
 
@@ -76,7 +80,7 @@ class Result(ABC):
         results_module = sys.modules[__name__]
         result_class = getattr(results_module, result_type)
 
-        result: Result = result_class(model.message)
+        result: Result = result_class(model.message, model.additional_data)
         result = result._with_evidence_metadata(model.evidence_metadata)
         return result
 
@@ -91,13 +95,13 @@ class Result(ABC):
 class Success(Result):
     """Indicates successful measurement validation."""
 
-    def __init__(self, message: str = ""):
+    def __init__(self, message: str = "", additional_data: str = ""):
         """
         Initialize a Success validation result instance.
 
         :param message: Optional message
         """
-        super().__init__(message)
+        super().__init__(message, additional_data)
 
     def __bool__(self) -> bool:
         """Implicit boolean conversion."""
@@ -111,13 +115,13 @@ class Success(Result):
 class Failure(Result):
     """Indicates failed measurement validation."""
 
-    def __init__(self, message: str = ""):
+    def __init__(self, message: str = "", additional_data: str = ""):
         """
         Initialize a Failure validation result instance.
 
         :param message: Optional message
         """
-        super().__init__(message)
+        super().__init__(message, additional_data)
 
     def __bool__(self) -> bool:
         """Implicit boolean conversion."""
@@ -131,13 +135,13 @@ class Failure(Result):
 class Info(Result):
     """Indicates an informational resut of measurement validation, not validated."""
 
-    def __init__(self, message: str):
+    def __init__(self, message: str, additional_data: str = ""):
         """
         Initialize an Info validatation result instance.
 
         :param message: Message indicating the reason validation is info
         """
-        super().__init__(message)
+        super().__init__(message, additional_data)
 
     def __bool__(self) -> bool:
         """Implicit boolean conversion."""

--- a/mlte/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/schema/artifact/report/v0.0.1/schema.json
@@ -953,6 +953,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -1009,6 +1017,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/schema/artifact/report/v0.0.1/schema.json
+++ b/mlte/schema/artifact/report/v0.0.1/schema.json
@@ -710,6 +710,10 @@
           "title": "Message",
           "type": "string"
         },
+        "additional_data": {
+          "title": "Additional Data",
+          "type": "string"
+        },
         "evidence_metadata": {
           "anyOf": [
             {
@@ -724,6 +728,7 @@
       "required": [
         "type",
         "message",
+        "additional_data",
         "evidence_metadata"
       ],
       "title": "ResultModel",

--- a/mlte/schema/artifact/results/v0.0.1/schema.json
+++ b/mlte/schema/artifact/results/v0.0.1/schema.json
@@ -56,6 +56,10 @@
           "title": "Message",
           "type": "string"
         },
+        "additional_data": {
+          "title": "Additional Data",
+          "type": "string"
+        },
         "evidence_metadata": {
           "anyOf": [
             {
@@ -70,6 +74,7 @@
       "required": [
         "type",
         "message",
+        "additional_data",
         "evidence_metadata"
       ],
       "title": "ResultModel",

--- a/mlte/schema/artifact/results/v0.0.1/schema.json
+++ b/mlte/schema/artifact/results/v0.0.1/schema.json
@@ -215,6 +215,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -271,6 +279,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/schema/artifact/tests/v0.0.1/schema.json
+++ b/mlte/schema/artifact/tests/v0.0.1/schema.json
@@ -141,6 +141,14 @@
           ],
           "title": "Failure"
         },
+        "default_success": {
+          "title": "Default Success",
+          "type": "string"
+        },
+        "default_failure": {
+          "title": "Default Failure",
+          "type": "string"
+        },
         "info": {
           "anyOf": [
             {
@@ -197,6 +205,8 @@
         "thresholds",
         "success",
         "failure",
+        "default_success",
+        "default_failure",
         "info"
       ],
       "title": "ValidatorModel",

--- a/mlte/store/artifact/underlying/rdbs/result_factory.py
+++ b/mlte/store/artifact/underlying/rdbs/result_factory.py
@@ -32,6 +32,7 @@ def create_results_orm(
         result_orm = DBResult(
             type=result.type,
             message=result.message,
+            additional_data=result.additional_data,
             test_results=test_results_orm,
             evidence_metadata=(
                 DBEvidenceMetadata(
@@ -56,6 +57,7 @@ def create_results_model(
                 result.evidence_metadata.test_case_id: ResultModel(
                     type=result.type,
                     message=result.message,
+                    additional_data=result.additional_data,
                     evidence_metadata=EvidenceMetadata(
                         test_case_id=result.evidence_metadata.test_case_id,
                         measurement=MeasurementMetadata.from_json_string(

--- a/mlte/store/artifact/underlying/rdbs/result_metadata.py
+++ b/mlte/store/artifact/underlying/rdbs/result_metadata.py
@@ -57,6 +57,7 @@ class DBResult(DBBase):
     id: Mapped[int] = mapped_column(primary_key=True)
     type: Mapped[str]
     message: Mapped[str]
+    additional_data: Mapped[str]
     test_results_id: Mapped[int] = mapped_column(ForeignKey("test_results.id"))
 
     evidence_metadata: Mapped[DBEvidenceMetadata] = relationship(

--- a/mlte/validation/model.py
+++ b/mlte/validation/model.py
@@ -25,6 +25,12 @@ class ValidatorModel(BaseModel):
     failure: Optional[str]
     """A string to be used when recording that the validation was not succesful."""
 
+    default_success: str
+    """A default string to be used when recording that the validation was succesful, if success is not defined, and in detailed messages.."""
+
+    default_failure: str
+    """A default string to be used when recording that the validation was not succesful, if failure is not defined, and in detailed messages."""
+
     info: Optional[str]
     """A string to be used when recording that the validation was not checked against a expression, just recorded information."""
 

--- a/mlte/validation/validator.py
+++ b/mlte/validation/validator.py
@@ -28,6 +28,8 @@ class Validator(Serializable):
         thresholds: list[str] = [],
         success: Optional[str] = None,
         failure: Optional[str] = None,
+        default_success: str = "",
+        default_failure: str = "",
         info: Optional[str] = None,
         input_types: list[str] = [],
         creator: Optional[FunctionInfo] = None,
@@ -39,10 +41,18 @@ class Validator(Serializable):
         :param thresholds: A list of serialized thesholds used in the bool exp, for auditing purposes.
         :param success: A string indicating the message to record in case of success (bool_exp evaluating to True).
         :param failure: A string indicating the message to record in case of failure (bool_exp evaluating to False).
+        :param default_success: A more generic value to use if success is not set.
+        :param default_failure: A more generic value to use if failure is not set.
         :param info: A string indicating the message to record in case no bool expression is passed (no condition, just recording information).
         :param input_types: A list of strings indicating the type of input the validator will expect.
         :param creator: Information about the class and method that created this validator, if any.
         """
+        # Use default if needed.
+        if not success:
+            success = default_success if default_success else None
+        if not failure:
+            failure = default_failure if default_failure else None
+
         if success is not None and failure is None:
             raise ValueError(
                 "If success message is defined, failure message has to be defined as well"
@@ -60,6 +70,8 @@ class Validator(Serializable):
         self.thresholds = thresholds.copy()
         self.success = success
         self.failure = failure
+        self.default_success = default_success
+        self.default_failure = default_failure
         self.info = info
         self.input_types = input_types
         self.creator = creator
@@ -77,6 +89,8 @@ class Validator(Serializable):
         thresholds: list[Any] = [],
         success: Optional[str] = None,
         failure: Optional[str] = None,
+        default_success: str = "",
+        default_failure: str = "",
         info: Optional[str] = None,
         input_types: list[type] = [Evidence],
     ) -> Validator:
@@ -87,6 +101,8 @@ class Validator(Serializable):
         :param thresholds: A list of thesholds used in the bool exp, potentially unit-aware, for auditing purposes.
         :param success: A string indicating the message to record in case of success (bool_exp evaluating to True).
         :param failure: A string indicating the message to record in case of failure (bool_exp evaluating to False).
+        :param default_success: A more generic value to use if success is not set.
+        :param default_failure: A more generic value to use if failure is not set.
         :param info: A string indicating the message to record in case no bool expression is passed (no condition, just recording information).
         :param input_types: A list of types indicating the type of input the validator will expect.
         :returns: A Validator, potentially with caller creator information.
@@ -102,6 +118,8 @@ class Validator(Serializable):
             thresholds=[str(threshold) for threshold in thresholds],
             success=success,
             failure=failure,
+            default_success=default_success,
+            default_failure=default_failure,
             info=info,
             input_types=[
                 meta.get_qualified_name(input_type)
@@ -154,9 +172,15 @@ class Validator(Serializable):
             Info(self.info)
             if self.bool_exp is None and self.info is not None
             else (
-                Success(f"{self.success}", additional_data=f"{values_str}")
+                Success(
+                    f"{self.success}",
+                    additional_data=f"{self.default_success}{values_str}",
+                )
                 if executed_bool_exp_value
-                else Failure(f"{self.failure}", additional_data=f"{values_str}")
+                else Failure(
+                    f"{self.failure}",
+                    additional_data=f"{self.default_failure}{values_str}",
+                )
             )
         )
         return result
@@ -200,7 +224,7 @@ class Validator(Serializable):
         str_kwargs = {key: str(arg) for key, arg in kwargs.items()}
 
         # Now string them together, depending on whether we got args of each type.
-        values = "- values: "
+        values = " - values: "
         if len(args) > 0:
             values = values + f"{json.dumps(str_args)}"
         if len(args) > 0 and len(kwargs) > 0:
@@ -229,6 +253,8 @@ class Validator(Serializable):
             thresholds=self.thresholds,
             success=self.success,
             failure=self.failure,
+            default_success=self.default_success,
+            default_failure=self.default_failure,
             info=self.info,
             bool_exp_str=self.bool_exp_str,
             input_types=self.input_types,
@@ -269,6 +295,8 @@ class Validator(Serializable):
             thresholds=model.thresholds,
             success=model.success,
             failure=model.failure,
+            default_success=model.default_success,
+            default_failure=model.default_failure,
             info=model.info,
             input_types=model.input_types,
             creator=(

--- a/mlte/validation/validator.py
+++ b/mlte/validation/validator.py
@@ -28,6 +28,8 @@ class Validator(Serializable):
         thresholds: list[str] = [],
         success: Optional[str] = None,
         failure: Optional[str] = None,
+        default_success: str = "",
+        default_failure: str = "",
         info: Optional[str] = None,
         input_types: list[str] = [],
         creator: Optional[FunctionInfo] = None,
@@ -39,6 +41,8 @@ class Validator(Serializable):
         :param thresholds: A list of serialized thesholds used in the bool exp, for auditing purposes.
         :param success: A string indicating the message to record in case of success (bool_exp evaluating to True).
         :param failure: A string indicating the message to record in case of failure (bool_exp evaluating to False).
+        :param default_success: A more generic value to use if success is not set.
+        :param default_failure: A more generic value to use if failure is not set.
         :param info: A string indicating the message to record in case no bool expression is passed (no condition, just recording information).
         :param input_types: A list of strings indicating the type of input the validator will expect.
         :param creator: Information about the class and method that created this validator, if any.
@@ -58,8 +62,14 @@ class Validator(Serializable):
 
         self.bool_exp = bool_exp
         self.thresholds = thresholds.copy()
-        self.success = success
-        self.failure = failure
+        self.success = (
+            success if success else default_success if default_success else None
+        )
+        self.failure = (
+            failure if failure else default_failure if default_failure else None
+        )
+        self.default_success = default_success
+        self.default_failure = default_failure
         self.info = info
         self.input_types = input_types
         self.creator = creator
@@ -77,6 +87,8 @@ class Validator(Serializable):
         thresholds: list[Any] = [],
         success: Optional[str] = None,
         failure: Optional[str] = None,
+        default_success: str = "",
+        default_failure: str = "",
         info: Optional[str] = None,
         input_types: list[type] = [Evidence],
     ) -> Validator:
@@ -87,6 +99,8 @@ class Validator(Serializable):
         :param thresholds: A list of thesholds used in the bool exp, potentially unit-aware, for auditing purposes.
         :param success: A string indicating the message to record in case of success (bool_exp evaluating to True).
         :param failure: A string indicating the message to record in case of failure (bool_exp evaluating to False).
+        :param default_success: A more generic value to use if success is not set.
+        :param default_failure: A more generic value to use if failure is not set.
         :param info: A string indicating the message to record in case no bool expression is passed (no condition, just recording information).
         :param input_types: A list of types indicating the type of input the validator will expect.
         :returns: A Validator, potentially with caller creator information.
@@ -102,6 +116,8 @@ class Validator(Serializable):
             thresholds=[str(threshold) for threshold in thresholds],
             success=success,
             failure=failure,
+            default_success=default_success,
+            default_failure=default_failure,
             info=info,
             input_types=[
                 meta.get_qualified_name(input_type)
@@ -154,9 +170,15 @@ class Validator(Serializable):
             Info(self.info)
             if self.bool_exp is None and self.info is not None
             else (
-                Success(f"{self.success}", additional_data=f"{values_str}")
+                Success(
+                    f"{self.success}",
+                    additional_data=f"{self.default_success}{values_str}",
+                )
                 if executed_bool_exp_value
-                else Failure(f"{self.failure}", additional_data=f"{values_str}")
+                else Failure(
+                    f"{self.failure}",
+                    additional_data=f"{self.default_failure}{values_str}",
+                )
             )
         )
         return result
@@ -200,7 +222,7 @@ class Validator(Serializable):
         str_kwargs = {key: str(arg) for key, arg in kwargs.items()}
 
         # Now string them together, depending on whether we got args of each type.
-        values = "- values: "
+        values = " - values: "
         if len(args) > 0:
             values = values + f"{json.dumps(str_args)}"
         if len(args) > 0 and len(kwargs) > 0:
@@ -229,6 +251,8 @@ class Validator(Serializable):
             thresholds=self.thresholds,
             success=self.success,
             failure=self.failure,
+            default_success=self.default_success,
+            default_failure=self.default_failure,
             info=self.info,
             bool_exp_str=self.bool_exp_str,
             input_types=self.input_types,
@@ -269,6 +293,8 @@ class Validator(Serializable):
             thresholds=model.thresholds,
             success=model.success,
             failure=model.failure,
+            default_success=model.default_success,
+            default_failure=model.default_failure,
             info=model.info,
             input_types=model.input_types,
             creator=(

--- a/mlte/validation/validator.py
+++ b/mlte/validation/validator.py
@@ -154,9 +154,9 @@ class Validator(Serializable):
             Info(self.info)
             if self.bool_exp is None and self.info is not None
             else (
-                Success(f"{self.success} {values_str}")
+                Success(f"{self.success}", additional_data=f"{values_str}")
                 if executed_bool_exp_value
-                else Failure(f"{self.failure} {values_str}")
+                else Failure(f"{self.failure}", additional_data=f"{values_str}")
             )
         )
         return result

--- a/test/fixture/artifact.py
+++ b/test/fixture/artifact.py
@@ -265,6 +265,7 @@ def _make_test_results() -> TestResultsModel:
             "Test1": ResultModel(
                 type="Success",
                 message="The RF accuracy is greater than 3",
+                additional_data="Details about the results: a lot of extra data about specific results.",
                 evidence_metadata=EvidenceMetadata(
                     test_case_id="Test1",
                     measurement=MeasurementMetadata(

--- a/test/validation/test_validator.py
+++ b/test/validation/test_validator.py
@@ -31,6 +31,8 @@ def get_sample_validator(add_creator: bool = False) -> Validator:
         success="Test was succesful!",
         failure="Test failed :(",
         info="Only data was attached",
+        default_success="Default success",
+        default_failure="Default failure",
         input_types=["builtins.int", "builtins.int"],
     )
 
@@ -61,8 +63,9 @@ class TestValue:
         validator: Validator = Validator.build_validator(
             bool_exp=lambda real: real.value > arg1 and real.value < arg2,
             thresholds=[arg1 * Units.meter, arg2],
-            success=f"Real magnitude is between {arg1} and {arg2}",
-            failure=f"Real magnitude is not between {arg1} and {arg2}",
+            default_success=f"Real magnitude is between {arg1} and {arg2}",
+            default_failure=f"Real magnitude is not between {arg1} and {arg2}",
+            input_types=[Integer],
         )
         return validator
 
@@ -72,8 +75,10 @@ class TestValue:
         validator: Validator = Validator.build_validator(
             bool_exp=lambda real: real.value > arg1 and arg2.data == str(real),
             thresholds=[arg1 * Units.meter, arg2],
-            success=f"Real magnitude is between {arg1} and {arg2}",
-            failure=f"Real magnitude is not between {arg1} and {arg2}",
+            success="OK everything went well",
+            failure="FAILURE problems",
+            default_success=f"Real magnitude is between {arg1} and {arg2}",
+            default_failure=f"Real magnitude is not between {arg1} and {arg2}",
         )
         return validator
 
@@ -103,14 +108,18 @@ def test_validator_model() -> None:
             bool_exp_str="test()",
             success="Test was succesful!",
             failure="Test failed :(",
+            default_success="SUCESSS",
+            default_failure="FAILURE",
             info="Only data was attached",
         ),
         ValidatorModel(
             bool_exp="ASJDH12384jahsd",
             bool_exp_str="test()",
             thresholds=[str(4 * Units.meter)],
-            success="Test was succesful!",
-            failure="Test failed :(",
+            success=None,
+            failure=None,
+            default_success="SUCESSS",
+            default_failure="FAILURE",
             info="Only data was attached",
             creator_entity="TestClass",
             creator_function="test_validator_model",
@@ -188,7 +197,8 @@ def test_validate_success() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: ["{x}", "{y}"]'
+        and result.additional_data
+        == f'{validator.default_success} - values: ["{x}", "{y}"]'
     )
 
 
@@ -204,7 +214,8 @@ def test_validate_success_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: {{"x": "{x}", "y": "{y}"}}'
+        and result.additional_data
+        == f'{validator.default_success} - values: {{"x": "{x}", "y": "{y}"}}'
     )
 
 
@@ -220,7 +231,8 @@ def test_validate_success_args_and_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: ["{x}"], {{"y": "{y}"}}'
+        and result.additional_data
+        == f'{validator.default_success} - values: ["{x}"], {{"y": "{y}"}}'
     )
 
 
@@ -236,7 +248,8 @@ def test_validate_failure() -> None:
     assert (
         validator.failure is not None
         and result.message == validator.failure
-        and result.additional_data == f'- values: ["{x}", "{y}"]'
+        and result.additional_data
+        == f'{validator.default_failure} - values: ["{x}", "{y}"]'
     )
 
 
@@ -274,7 +287,8 @@ def test_validate_success_with_evidence() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == '- values: ["1"]'
+        and result.additional_data
+        == f'{validator.default_success} - values: ["1"]'
     )
 
 
@@ -298,8 +312,37 @@ def test_invalid_input_types() -> None:
 
 
 def test_json_fix_serializable_argument():
+    """Tests that json fix helps serialize arguments."""
     test_value = JsonValue()
     validator = TestValue.json_method(test_value)
 
     json_data = validator.to_model().to_json()
     _ = json.dumps(json_data)
+
+
+def test_validate_with_test_defaults():
+    """Defaults are used if success and failure are note defined."""
+    validator = TestValue.in_between(1, 3)
+    x = Integer(2)
+
+    result = validator.validate(x)
+
+    assert (
+        validator.success is not None
+        and result.message == validator.default_success
+    )
+
+
+def test_validate_ignore_test_defaults():
+    """Defaults are ignored if success and failure are defined."""
+    validator = get_sample_validator()
+    x = 1
+    y = 2
+
+    result = validator.validate(x, y)
+
+    assert (
+        validator.failure is not None
+        and result.message != validator.default_failure
+        and result.message == validator.failure
+    )

--- a/test/validation/test_validator.py
+++ b/test/validation/test_validator.py
@@ -187,7 +187,8 @@ def test_validate_success() -> None:
 
     assert (
         validator.success is not None
-        and result.message == validator.success + f' - values: ["{x}", "{y}"]'
+        and result.message == validator.success
+        and result.additional_data == f'- values: ["{x}", "{y}"]'
     )
 
 
@@ -202,8 +203,8 @@ def test_validate_success_kwargs() -> None:
 
     assert (
         validator.success is not None
-        and result.message
-        == validator.success + f' - values: {{"x": "{x}", "y": "{y}"}}'
+        and result.message == validator.success
+        and result.additional_data == f'- values: {{"x": "{x}", "y": "{y}"}}'
     )
 
 
@@ -218,8 +219,8 @@ def test_validate_success_args_and_kwargs() -> None:
 
     assert (
         validator.success is not None
-        and result.message
-        == validator.success + f' - values: ["{x}"], {{"y": "{y}"}}'
+        and result.message == validator.success
+        and result.additional_data == f'- values: ["{x}"], {{"y": "{y}"}}'
     )
 
 
@@ -234,7 +235,8 @@ def test_validate_failure() -> None:
 
     assert (
         validator.failure is not None
-        and result.message == validator.failure + f' - values: ["{x}", "{y}"]'
+        and result.message == validator.failure
+        and result.additional_data == f'- values: ["{x}", "{y}"]'
     )
 
 
@@ -271,7 +273,8 @@ def test_validate_success_with_evidence() -> None:
 
     assert (
         validator.success is not None
-        and result.message == validator.success + ' - values: ["1"]'
+        and result.message == validator.success
+        and result.additional_data == '- values: ["1"]'
     )
 
 

--- a/test/validation/test_validator.py
+++ b/test/validation/test_validator.py
@@ -61,8 +61,10 @@ class TestValue:
         validator: Validator = Validator.build_validator(
             bool_exp=lambda real: real.value > arg1 and real.value < arg2,
             thresholds=[arg1 * Units.meter, arg2],
-            success=f"Real magnitude is between {arg1} and {arg2}",
-            failure=f"Real magnitude is not between {arg1} and {arg2}",
+            success="OK everything went well",
+            failure="FAILURE problems",
+            default_success=f"Real magnitude is between {arg1} and {arg2}",
+            default_failure=f"Real magnitude is not between {arg1} and {arg2}",
         )
         return validator
 
@@ -72,8 +74,8 @@ class TestValue:
         validator: Validator = Validator.build_validator(
             bool_exp=lambda real: real.value > arg1 and arg2.data == str(real),
             thresholds=[arg1 * Units.meter, arg2],
-            success=f"Real magnitude is between {arg1} and {arg2}",
-            failure=f"Real magnitude is not between {arg1} and {arg2}",
+            default_success=f"Real magnitude is between {arg1} and {arg2}",
+            default_failure=f"Real magnitude is not between {arg1} and {arg2}",
         )
         return validator
 
@@ -103,14 +105,18 @@ def test_validator_model() -> None:
             bool_exp_str="test()",
             success="Test was succesful!",
             failure="Test failed :(",
+            default_success="SUCESSS",
+            default_failure="FAILURE",
             info="Only data was attached",
         ),
         ValidatorModel(
             bool_exp="ASJDH12384jahsd",
             bool_exp_str="test()",
             thresholds=[str(4 * Units.meter)],
-            success="Test was succesful!",
-            failure="Test failed :(",
+            success=None,
+            failure=None,
+            default_success="SUCESSS",
+            default_failure="FAILURE",
             info="Only data was attached",
             creator_entity="TestClass",
             creator_function="test_validator_model",
@@ -188,7 +194,7 @@ def test_validate_success() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: ["{x}", "{y}"]'
+        and result.additional_data == f' - values: ["{x}", "{y}"]'
     )
 
 
@@ -204,7 +210,7 @@ def test_validate_success_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: {{"x": "{x}", "y": "{y}"}}'
+        and result.additional_data == f' - values: {{"x": "{x}", "y": "{y}"}}'
     )
 
 
@@ -220,7 +226,7 @@ def test_validate_success_args_and_kwargs() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == f'- values: ["{x}"], {{"y": "{y}"}}'
+        and result.additional_data == f' - values: ["{x}"], {{"y": "{y}"}}'
     )
 
 
@@ -236,7 +242,7 @@ def test_validate_failure() -> None:
     assert (
         validator.failure is not None
         and result.message == validator.failure
-        and result.additional_data == f'- values: ["{x}", "{y}"]'
+        and result.additional_data == f' - values: ["{x}", "{y}"]'
     )
 
 
@@ -274,7 +280,7 @@ def test_validate_success_with_evidence() -> None:
     assert (
         validator.success is not None
         and result.message == validator.success
-        and result.additional_data == '- values: ["1"]'
+        and result.additional_data.endswith(' - values: ["1"]')
     )
 
 


### PR DESCRIPTION
Fixes #863. More specifically:
 - Modified Result artifact to have an additional field, "additional_data". Now instead of cramming all detailed results into the "message" field, that field is reserved to a more user-friendly message (if any), and the "additional_data" field is used to store a more technical/default/detailed message. If there is no user friendly message added when this is used, the same more generic/techincal message will be put on both fields, but the details about the input data used when validating will only be attached to the additional_data field, so the message field will still be cleaner/shorter.
 - Modified Validator and its constructor methods to allow for 2 sets of messages for success and failure cases. There is a "default" message for each which is usually used by the built in Validator generators to put a more generic explanation of each success/failure, and there there is a separate success/failure message string that can be used by external entities creating validators to add a more context-dependent successs/failure message. If used, this is what will end up in the "message" field of the Result.
 - Modified all built-in Validator creation methods to accept an optional success/failure message. If passed to them, it is used as the main "message" eventually stored with the Result. This allows callers of those validator generation methods to pass more context-aware successs/failure messages that may mean more to the users. However, these are optional values, so by default they are not passed nor used, and the current internal, more generic messages will still end up being used. So currently this part of the capability is not really used, until the demos are updated to add more user friendly and context-aware messages.

To clarify, this PR mostly adds that feature that is not fully used by the demos yet. The only change that can be seen from using this version is that the details of the inputs used for a validation no longer appear in the Report result success/failure message as they end up hidden in the new additional_data field.

A followup issue will be later created to update the demos to take advantage of the friendlier user messages. We could potentially discuss also seeing if we want to have the "additional_data" field being shown somewhere in the Frontend. The whole point was to basically hide the detailed info there, and it is still there in the JSON/DB, but we may want to add a way to expose it if someone wants to dig in without having to look into the JSON files, even if it doesn't show up in, for example, the exported report.