### PR TITLE
Added in GB risks to the negotiation card

### DIFF
--- a/demo/GardenBuddy/1_requirements.ipynb
+++ b/demo/GardenBuddy/1_requirements.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "if len(card.system.risks) > 0:\n",
     "    print(\n",
-    "        \"The stakeholder perceived risks to the system are: \",\n",
+    "        \"The stakeholder perceived risks to the system are: \\n  -\",\n",
     "        \"\\n  - \".join(card.system.risks),\n",
     "    )"
    ]

--- a/demo/sample_store/models/GardenBuddy/card.default.json
+++ b/demo/sample_store/models/GardenBuddy/card.default.json
@@ -36,7 +36,10 @@
             "problem_type": "Classification",
             "task": "Identify flowers in pictures taken at the garden",
             "usage_context": "The model will be part of an application that runs on a device loaned out by a botanical garden so that visitors can identify flowers during their visit.",
-            "risks": []
+            "risks": [
+                "Poor user experience due to incorrectly identified flowers",
+                "Poor user experience due to inability to identify flowers"
+            ]
         },
         "data": [
             {


### PR DESCRIPTION
The fixes should re-add the risks to the Garden Buddy demo; the ReviewPro and Gradient Climber demos didn't have the risks missing. 

Changes were: Added the Garden Buddy risks to the negotiation card in the sample_store, and fixed the printing of the risks in the 1_requirements.ipynb notebook