### PR TITLE
Generic run_environment script 

### DIFF
--- a/demo/run_environment.sh
+++ b/demo/run_environment.sh
@@ -1,30 +1,8 @@
 #!/usr/bin/env bash
 
-# Ensure everything stops if there is a failure in one of the commands.
-set -e
-
-DOCKER_FOLDER=../docker/deployment
-
-# Function to stop env.
-function cleanup() {
-    echo "Cleaning up..."
-    (cd $DOCKER_FOLDER && source stop.sh)
-    exit 130
-}
-
-# Set up cleanup function to be called if Ctrl+C is used.
-trap cleanup SIGINT
-
 # Needed to copy sample cards.
 cp -r ./sample_store ./store
 
-# Set env vars to not use a relational DB, but a file store, and point to the one here.
-export STORE_TYPE=fs
-export HOST_FS_STORE="$(pwd -P)/store"
-echo "Mounting store on local absolute path ${HOST_FS_STORE}"
-
-# We will use dockerized versions of frontend and backend. This will also build them if needed.
-(cd $DOCKER_FOLDER && source rebuild_and_restart.sh)
-
-# Unlikely we'll get there, but explicitly call cleanup if the running server scripts stopped for another reason.
-cleanup
+# Point to our demo local store and run the environment.
+HOST_FS_STORE="$(pwd -P)/store"
+(cd ../ && source ./run_environment.sh "${HOST_FS_STORE}")

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -12,8 +12,14 @@ $ pyenv local 3.12
 $ make venv
 ```
 
-The other part of MLTE is the frontend and backend. These are used for visualizing the results of the SDMT process and provide a user-friendly interface to create the [Negotiation Card](negotiation_card.md) . This can be setup as explained in the demo section by using the `demo/run_environment.sh` script. This will start `MLTE` as 2 docker containers with a file system based store. This store will be populated with the data in `demo/store` which will include sample models, versions and [Negotiation Cards](negotiation_card.md) along with any results created by running the demo notebooks. This is volume mounted so any changes made using the frontend will be available locally in that same directory. The frontend will be available at `localhost:8000`.
+The other part of MLTE is the frontend and backend. These are used for visualizing the results of the SDMT process and provide a user-friendly interface to create the [Negotiation Card](negotiation_card.md) . This can be setup manually or by using the `run_environment.sh` script. This will start `MLTE` as 2 docker containers with an empty file system based store. If the script `demo/run_environment.sh` is used instead, the store will be populated with the data in `demo/store`, which will include sample models, versions and [Negotiation Cards](negotiation_card.md) along with any results created by running the demo notebooks. This is volume mounted so any changes made using the frontend will be available locally in that same directory. The frontend will be available at `localhost:8000`.
 
+For an empty store:
+```bash
+bash run_environment.sh
+```
+
+To use the demo store:
 ```bash
 cd demo && bash run_environment.sh
 ```

--- a/run_environment.sh
+++ b/run_environment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Starts up a MLTE environment with a local file store. 
+# The folder can be provided as an argument, or it will default to ./store.
+
+# Ensure everything stops if there is a failure in one of the commands.
+set -e
+
+DOCKER_FOLDER=./docker/deployment
+
+# Function to stop env.
+function cleanup() {
+    echo "Cleaning up..."
+    (cd $DOCKER_FOLDER && source stop.sh)
+    exit 130
+}
+
+# Set up cleanup function to be called if Ctrl+C is used.
+trap cleanup SIGINT
+
+# Get store from argument and set it, or default to ./store if not provided.
+export HOST_FS_STORE="${1:-$(pwd -P)/store}"
+
+# Set env vars to not use a relational DB, but a file store, and point to the provided one.
+export STORE_TYPE=fs
+echo "Mounting store on local absolute path ${HOST_FS_STORE}"
+
+# We will use dockerized versions of frontend and backend. This will also build them if needed.
+(cd $DOCKER_FOLDER && source rebuild_and_restart.sh)
+
+# Explicitly call cleanup when the running server scripts stop.
+cleanup


### PR DESCRIPTION
Fixes #881 by creating a generic run environment script that can be used to start an empty MLTE instance, or point it to whatever store is needed. The script in demo/ now simply calls the generic script, though externally it produces the same result.