### PR TITLE
Feature/report export polishing

### DIFF
--- a/mlte/frontend/nuxt-app/components/Report/results-table.vue
+++ b/mlte/frontend/nuxt-app/components/Report/results-table.vue
@@ -38,7 +38,11 @@
           </div>
         </td>
         <td v-if="result.evidence_metadata">
-          {{ result.evidence_metadata.measurement.measurement_class.split('.').at(-1) }}
+          {{
+            result.evidence_metadata.measurement.measurement_class
+              .split(".")
+              .at(-1)
+          }}
         </td>
         <td v-else>Manually validated</td>
         <td v-if="result.evidence_metadata">

--- a/mlte/frontend/nuxt-app/components/Report/results-table.vue
+++ b/mlte/frontend/nuxt-app/components/Report/results-table.vue
@@ -38,7 +38,7 @@
           </div>
         </td>
         <td v-if="result.evidence_metadata">
-          {{ result.evidence_metadata.measurement.measurement_class }}
+          {{ result.evidence_metadata.measurement.measurement_class.split('.').at(-1) }}
         </td>
         <td v-else>Manually validated</td>
         <td v-if="result.evidence_metadata">

--- a/mlte/frontend/nuxt-app/pages/artifact/report-export.vue
+++ b/mlte/frontend/nuxt-app/pages/artifact/report-export.vue
@@ -17,9 +17,8 @@
       <div class="spacer"></div>
 
       <div class="header-authors">
-        author details <br />
-        author details <br />
-        author details
+        {{ creator }} <br />
+        {{ timestamp }}
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #814 and #894 in exported Report in Frontend:
 - Adds actual creator and timestamp to header in exported report, instead of previously hardcoded "author details"
 - Clips measurement class name to show only class and not full package path, as it is not needed in these views and it messes up the visual structure of the table