### PR TITLE
Artifact Overwrite Unit Test Bug Fix

### DIFF
--- a/mlte/report/artifact.py
+++ b/mlte/report/artifact.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import datetime
-import typing
 import re
+import typing
 
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactModel
@@ -142,7 +142,7 @@ class Report(Artifact):
         :param store: The store in which to save the artifact
         """
         # Ensure that, if the id already had a timestamp, it is removed first.
-        timestamp_suffix = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+        timestamp_suffix = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         cleaned_id = re.sub(r"-\d{8}-\d{6}$", "", self.identifier)
         self.identifier = f"{cleaned_id}-{timestamp_suffix}"
 

--- a/mlte/report/artifact.py
+++ b/mlte/report/artifact.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import typing
+import re
 
 from mlte.artifact.artifact import Artifact
 from mlte.artifact.model import ArtifactModel
@@ -139,9 +140,11 @@ class Report(Artifact):
         Override Artifact.pre_save_hook(). Assigns time-stamped id to report, to ensure all have different ids.
         :param context: The context in which to save the artifact
         :param store: The store in which to save the artifact
-        :raises RuntimeError: On broken invariant
         """
-        self.identifier = f"{self.identifier}-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        # Ensure that, if the id already had a timestamp, it is removed first.
+        timestamp_suffix = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+        cleaned_id = re.sub(r"-\d{8}-\d{6}$", "", self.identifier)
+        self.identifier = f"{cleaned_id}-{timestamp_suffix}"
 
     # ----------------------------------------------------------------------------------
     # Helper methods.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ test =[
 tools = [
     "jsonschema==4.26.0",
     "bump2version==1.0.1",
-    "twine==6.2.0",
+    "twine==7.0.0",
 ]
 
 [tool.hatch.build]

--- a/test/backend/api/auth/test_authentication.py
+++ b/test/backend/api/auth/test_authentication.py
@@ -30,7 +30,7 @@ def set_test_user(
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_authenticate_valid_user(
     store_type: StoreType, create_test_user_store
 ) -> None:
@@ -51,7 +51,7 @@ def test_authenticate_valid_user(
         assert success
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_authenticate_inexistent_user(
     store_type: StoreType, create_test_user_store
 ) -> None:
@@ -70,7 +70,7 @@ def test_authenticate_inexistent_user(
         assert not success
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_authenticate_wrong_password(
     store_type: StoreType, create_test_user_store
 ) -> None:

--- a/test/session/test_session.py
+++ b/test/session/test_session.py
@@ -49,7 +49,7 @@ def test_session() -> None:
     assert s.stores.catalog_stores.catalogs[cat_id].uri.uri == catalog_store_uri
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_eager_context_creation(
     store_type: StoreType, create_test_artifact_store, patched_setup_stores
 ) -> None:

--- a/test/store/artifact/test_underlying.py
+++ b/test/store/artifact/test_underlying.py
@@ -19,7 +19,7 @@ from test.store.artifact.conftest import store_types_and_artifact_types
 from test.store.utils import store_types
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_init_store(store_type: StoreType, create_test_artifact_store) -> None:
     """A store can be initialized."""
     _ = create_test_artifact_store(store_type)
@@ -28,7 +28,7 @@ def test_init_store(store_type: StoreType, create_test_artifact_store) -> None:
     assert True
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_model(store_type: StoreType, create_test_artifact_store) -> None:
     """An artifact store supports model operations."""
     store: ArtifactStore = create_test_artifact_store(store_type)
@@ -49,7 +49,7 @@ def test_model(store_type: StoreType, create_test_artifact_store) -> None:
             artifact_store.model_mapper.read(model_id)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_model_list(store_type: StoreType, create_test_artifact_store) -> None:
     """Models can be listed."""
     store: ArtifactStore = create_test_artifact_store(store_type)
@@ -64,7 +64,7 @@ def test_model_list(store_type: StoreType, create_test_artifact_store) -> None:
         assert models[0] == "model0"
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_version(store_type: StoreType, create_test_artifact_store) -> None:
     """An artifact store supports model version operations."""
     store: ArtifactStore = create_test_artifact_store(store_type)
@@ -90,7 +90,7 @@ def test_version(store_type: StoreType, create_test_artifact_store) -> None:
             _ = artifact_store.version_mapper.read(version_id, model_id)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_two_versions_same_id_same_model(
     store_type: StoreType, create_test_artifact_store
 ) -> None:
@@ -112,7 +112,7 @@ def test_two_versions_same_id_same_model(
             )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_two_versions_same_id_different_model(
     store_type: StoreType, create_test_artifact_store
 ) -> None:
@@ -136,7 +136,7 @@ def test_two_versions_same_id_different_model(
         )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_version_list(
     store_type: StoreType, create_test_artifact_store
 ) -> None:
@@ -190,7 +190,7 @@ def check_artifact_writing(
 
 
 @pytest.mark.parametrize(
-    "store_type,artifact_type", store_types_and_artifact_types()
+    "store_type,artifact_type", list(store_types_and_artifact_types())
 )
 def test_search(
     store_type: StoreType,
@@ -225,7 +225,7 @@ def test_search(
 
 
 @pytest.mark.parametrize(
-    "store_type,artifact_type", store_types_and_artifact_types()
+    "store_type,artifact_type", list(store_types_and_artifact_types())
 )
 def test_artifact(
     store_type: StoreType,
@@ -272,7 +272,7 @@ def test_artifact(
 
 
 @pytest.mark.parametrize(
-    "store_type,artifact_type", store_types_and_artifact_types()
+    "store_type,artifact_type", list(store_types_and_artifact_types())
 )
 def test_artifact_without_parents(
     store_type: StoreType,
@@ -298,7 +298,7 @@ def test_artifact_without_parents(
 
 
 @pytest.mark.parametrize(
-    "store_type,artifact_type", store_types_and_artifact_types()
+    "store_type,artifact_type", list(store_types_and_artifact_types())
 )
 def test_artifact_overwrite(
     store_type: StoreType,
@@ -344,7 +344,7 @@ def test_artifact_overwrite(
         )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_invalid_chars(
     store_type: StoreType, create_test_artifact_store
 ) -> None:

--- a/test/store/artifact/test_underlying.py
+++ b/test/store/artifact/test_underlying.py
@@ -312,6 +312,10 @@ def test_artifact_overwrite(
     version_id = "version0"
     artifact_id = "myid"
 
+    # Skip for Report, as it can never be overritten, since it changes its id each time it is generated.
+    if artifact_type == ArtifactType.REPORT:
+        return
+
     with ManagedArtifactSession(store.session()) as artifact_store:
         artifact_store.model_mapper.create(Model(identifier=model_id))
         artifact_store.version_mapper.create(

--- a/test/store/catalog/test_underlying.py
+++ b/test/store/catalog/test_underlying.py
@@ -36,7 +36,7 @@ def create_store_with_mem_cat(
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_init_store(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],
@@ -48,7 +48,7 @@ def test_init_store(
     assert True
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_catalog_entry(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],
@@ -96,7 +96,7 @@ def test_catalog_entry(
             catalog_store.entry_mapper.read(test_entry.header.identifier)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_catalog_group(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],
@@ -137,7 +137,7 @@ def test_catalog_group(
         assert len(entries) == 2
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_list_details(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],
@@ -169,7 +169,7 @@ def test_list_details(
         assert len(entries) == original_len + 2
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_search(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],
@@ -202,7 +202,7 @@ def test_search(
         assert len(entries) == original_len + 2
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_invalid_chars(
     store_type: StoreType,
     create_test_catalog_store: Callable[[StoreType], CatalogStore],

--- a/test/store/cross_validators/test_cross_validators.py
+++ b/test/store/cross_validators/test_cross_validators.py
@@ -25,7 +25,7 @@ VALID_USER = "admin"
 INVALID_USER = "not a user"
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_artifact_cross_validators(
     store_type: StoreType, tmp_path: Path, patched_setup_stores
 ) -> None:
@@ -116,7 +116,7 @@ def test_artifact_cross_validators(
             )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_catalog_cross_validators(
     store_type: StoreType, tmp_path: Path, patched_setup_stores
 ) -> None:

--- a/test/store/custom_list/test_underlying.py
+++ b/test/store/custom_list/test_underlying.py
@@ -11,7 +11,7 @@ from test.store.custom_list.conftest import get_test_entry, get_test_list
 from test.store.utils import store_types
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_init_store(
     store_type: StoreType, create_test_custom_list_store
 ) -> None:
@@ -22,7 +22,7 @@ def test_init_store(
     assert True
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_custom_list_entry(
     store_type: StoreType, create_test_custom_list_store
 ) -> None:
@@ -73,7 +73,7 @@ def test_custom_list_entry(
             )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_custom_list_parent_mappings(
     store_type: StoreType, create_test_custom_list_store
 ) -> None:

--- a/test/store/import_export/test_export.py
+++ b/test/store/import_export/test_export.py
@@ -51,7 +51,7 @@ from test.store.user.test_underlying import (
 from test.store.utils import store_types
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export_to_file(
     store_type: StoreType, tmp_path: Path, patched_setup_stores, patched_export
 ) -> None:
@@ -88,7 +88,7 @@ def test_export_to_file(
             assert export_json[CATALOG_KEY] == CATALOG_EXPORT_DATA
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export(
     store_type: StoreType, tmp_path: Path, patched_setup_stores, patched_export
 ) -> None:
@@ -114,7 +114,7 @@ def test_export(
     assert export[CATALOG_KEY] == CATALOG_EXPORT_DATA
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export_artifacts(
     store_type: StoreType,
     tmp_path: Path,
@@ -181,7 +181,7 @@ def test_export_artifacts(
     assert none_export == {}
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export_custom_lists(
     store_type: StoreType,
     tmp_path: Path,
@@ -217,7 +217,7 @@ def test_export_custom_lists(
     assert none_export == {}
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export_users(
     store_type: StoreType,
     tmp_path: Path,
@@ -266,7 +266,7 @@ def test_export_users(
     assert none_export == {}
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_export_catalogs(
     store_type: StoreType, tmp_path: Path, patched_setup_stores
 ) -> None:

--- a/test/store/import_export/test_import.py
+++ b/test/store/import_export/test_import.py
@@ -32,7 +32,7 @@ from test.store.import_export.conftest import (
 from test.store.utils import store_types
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_import(
     store_type: StoreType,
     tmp_path: Path,
@@ -70,7 +70,7 @@ def test_import(
     )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_import_artifacts(
     store_type: StoreType,
     tmp_path: Path,
@@ -98,7 +98,7 @@ def test_import_artifacts(
         )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_import_custom_lists(
     store_type: StoreType,
     tmp_path: Path,
@@ -123,7 +123,7 @@ def test_import_custom_lists(
         )
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_import_users(
     store_type: StoreType,
     tmp_path: Path,
@@ -143,7 +143,7 @@ def test_import_users(
         assert User(**user) == user_store_session.user_mapper.read(username)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_import_catalogs(
     store_type: StoreType,
     tmp_path: Path,

--- a/test/store/test_unified_store.py
+++ b/test/store/test_unified_store.py
@@ -21,7 +21,7 @@ def test_add_catalog_store_from_uri():
     assert cat_id in session_stores.catalog_stores.catalogs
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_setup_stores(store_type: StoreType, tmp_path, patched_setup_stores):
     session_stores = create_test_unified_store(
         store_type, tmp_path, patched_setup_stores
@@ -33,7 +33,7 @@ def test_setup_stores(store_type: StoreType, tmp_path, patched_setup_stores):
     assert session_stores.catalog_stores.catalogs != {}
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_setup_stores_with_catalog_uris(
     store_type: StoreType, tmp_path, patched_setup_stores
 ):

--- a/test/store/user/test_policy.py
+++ b/test/store/user/test_policy.py
@@ -53,7 +53,7 @@ class TestPolicy:
             assert found_permissions[MethodType.POST]
 
     @staticmethod
-    @pytest.mark.parametrize("store_type", store_types())
+    @pytest.mark.parametrize("store_type", list(store_types()))
     def test_save_remove(
         resource_type: ResourceType,
         id: str,
@@ -105,7 +105,7 @@ class TestPolicy:
             assert group in user.groups
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_create_policy_if_needed(
     store_type: StoreType,
     create_test_artifact_store,

--- a/test/store/user/test_underlying.py
+++ b/test/store/user/test_underlying.py
@@ -94,7 +94,7 @@ def get_internal_store_session(
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_init_store(store_type: StoreType, create_test_user_store) -> None:
     """A store can be initialized."""
     _ = create_test_user_store(store_type)
@@ -103,7 +103,7 @@ def test_init_store(store_type: StoreType, create_test_user_store) -> None:
     assert True
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_user(store_type: StoreType, create_test_user_store) -> None:
     """An artifact store supports user operations."""
     user_store: UserStore = create_test_user_store(store_type)
@@ -158,7 +158,7 @@ def test_user(store_type: StoreType, create_test_user_store) -> None:
             user_store_session.user_mapper.read(test_user.username)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_user_group_change(
     store_type: StoreType, create_test_user_store
 ) -> None:
@@ -201,7 +201,7 @@ def test_user_group_change(
         assert found_group == updated_group
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_group(store_type: StoreType, create_test_user_store) -> None:
     """An artifact store supports group operations."""
     store: UserStore = create_test_user_store(store_type)
@@ -241,7 +241,7 @@ def test_group(store_type: StoreType, create_test_user_store) -> None:
             user_store.group_mapper.read(test_group.name)
 
 
-@pytest.mark.parametrize("store_type", store_types())
+@pytest.mark.parametrize("store_type", list(store_types()))
 def test_permission(store_type: StoreType, create_test_user_store) -> None:
     """An artifact store supports permission operations."""
 


### PR DESCRIPTION
Fixes #736, and removes some testing warnings. More specifically:

 - Issue #736 was due specifically to how Report ids work. The problem always happened in the overwrite test for a report. The problem is that, by definition, reports can never be overwritten, as, whenever they are saved, their id is updated to add a timestamp. Thus, the test was not valid for reports. But since the timestamp has seconds-level granularity, it could happen that, between writing and overwriting a report, the timestamp could change by 1 second or not, depending on the timing of the test. In the first case (same timestamp generated as still running in the same second) the test would pass, in the second case (new timestamp generated since a second passed) the test would fail as the new report would have a new id and the check to see if it existed failed. Fixed by simply skipping that test for Reports, since it does not make sense for that artifact type.
 - Also fixed a related bug, in that the hook adding the timestamp to a report id could append more timestamps after previous ones. While a case not in a regular workflow, it could happen. Now, it removes any potential timestamp from a report id before appending a new one.
 - Also fixed warning from newer pytest versions of not using generators as parametrized values (and converting them to lists instead).